### PR TITLE
gyp: Enabling /ZW compile option

### DIFF
--- a/tools/gyp/pylib/gyp/MSVSSettings.py
+++ b/tools/gyp/pylib/gyp/MSVSSettings.py
@@ -592,6 +592,7 @@ _Same(_compile, 'UndefinePreprocessorDefinitions', _string_list)  # /U
 _Same(_compile, 'UseFullPaths', _boolean)  # /FC
 _Same(_compile, 'WholeProgramOptimization', _boolean)  # /GL
 _Same(_compile, 'XMLDocumentationFileName', _file_name)
+_Same(_compile, 'CompileAsWinRT', _boolean)  # /ZW
 
 _Same(_compile, 'AssemblerOutput',
       _Enumeration(['NoListing',

--- a/tools/gyp/pylib/gyp/generator/msvs.py
+++ b/tools/gyp/pylib/gyp/generator/msvs.py
@@ -256,6 +256,8 @@ def _ToolSetOrAppend(tools, tool_name, setting, value, only_if_unset=False):
   if not tools.get(tool_name):
     tools[tool_name] = dict()
   tool = tools[tool_name]
+  if 'CompileAsWinRT' == setting:  
+    return  
   if tool.get(setting):
     if only_if_unset: return
     if type(tool[setting]) == list and type(value) == list:


### PR DESCRIPTION
The change enables addons to compile with the [/ZW](https://msdn.microsoft.com/en-us/library/hh561383.aspx) (CompileAsWinRT) option when using node-gyp. e.g. if you have something like this in binding.gyp:

'targets': [
    {
      'target_name': 'foo',
      'sources': [
        'bar.cpp',
      ],
      'msvs_settings': {
        'VCCLCompilerTool': {
          'CompileAsWinRT': 'true',
        },
      },

The change in MSVSSettings.py gets rid of the warning below:
_Warning: unrecognized setting VCCLCompilerTool/CompileAsWinRT while converting to MSBuild._

The change in msvs.py gets rid of the error below:
_TypeError: Appending "false" to a non-list setting "CompileAsWinRT" for tool "ClCompile" is not allowed, previous value: true_
