### PR TITLE
chakrashim: allow Persistent::Reset after V8::Dispose

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -2453,7 +2453,7 @@ bool PersistentBase<T>::IsWeak() const {
 
 template <class T>
 void PersistentBase<T>::Reset() {
-  if (this->IsEmpty()) return;
+  if (this->IsEmpty() || V8::IsDead()) return;
 
   if (IsWeak()) {
     if (_weakWrapper.unique()) {

--- a/deps/chakrashim/src/v8v8.cc
+++ b/deps/chakrashim/src/v8v8.cc
@@ -26,6 +26,7 @@
 
 namespace v8 {
 
+bool g_disposed = false;
 bool g_exposeGC = false;
 bool g_useStrict = false;
 ArrayBuffer::Allocator* g_arrayBufferAllocator = nullptr;
@@ -124,6 +125,9 @@ void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
 }
 
 bool V8::Initialize() {
+  if (g_disposed) {
+    return false; // Can no longer Initialize if Disposed
+  }
 #ifndef NODE_ENGINE_CHAKRACORE
   if (g_EnableDebug && JsStartDebugging() != JsNoError) {
     return false;
@@ -142,11 +146,11 @@ void V8::SetArrayBufferAllocator(ArrayBuffer::Allocator* allocator) {
 }
 
 bool V8::IsDead() {
-  // CHAKRA-TODO
-  return false;
+  return g_disposed;
 }
 
 bool V8::Dispose() {
+  g_disposed = true;
   jsrt::IsolateShim::DisposeAll();
   Debug::Dispose();
   return true;


### PR DESCRIPTION
Some addons use global static Persistent to hold references. ~Persistent()
and Persistent::Reset() are called at process exit when the runtime has
already been disposed.

Add a global g_disposed flag to record V8::Dispose()/V8::IsDead() state.
Make Persistent::Reset() no-op if V8::IsDead(). This allows above scenario.
