### PR TITLE
chakrashim: fix ObjectTemplate callbacks compat

### DIFF
--- a/deps/chakrashim/src/v8chakra.h
+++ b/deps/chakrashim/src/v8chakra.h
@@ -116,8 +116,7 @@ class Utils {
 
   static JsValueRef HasPropertyHandler(
     JsValueRef *arguments,
-    unsigned short argumentCount,
-    bool checkInPrototype);
+    unsigned short argumentCount);
   static JsValueRef CALLBACK HasCallback(
     JsValueRef callee,
     bool isConstructCall,

--- a/deps/chakrashim/src/v8object.cc
+++ b/deps/chakrashim/src/v8object.cc
@@ -239,8 +239,13 @@ Local<Value> Object::GetOwnPropertyDescriptor(Local<String> key) {
 }
 
 Maybe<bool> Object::Has(Local<Context> context, Local<Value> key) {
+  JsPropertyIdRef idRef;
+  if (GetPropertyIdFromValue((JsValueRef)*key, &idRef) != JsNoError) {
+    return Nothing<bool>();
+  }
+
   bool result;
-  if (jsrt::HasProperty(this, *key, &result) != JsNoError) {
+  if (JsHasProperty(this, idRef, &result) != JsNoError) {
     return Nothing<bool>();
   }
 
@@ -252,12 +257,17 @@ bool Object::Has(Handle<Value> key) {
 }
 
 Maybe<bool> Object::Delete(Local<Context> context, Local<Value> key) {
-  JsValueRef resultRef;
-  if (jsrt::DeleteProperty(this, *key, &resultRef) != JsNoError) {
+  JsPropertyIdRef idRef;
+  if (GetPropertyIdFromValue((JsValueRef)*key, &idRef) != JsNoError) {
     return Nothing<bool>();
   }
 
-  return Just(Local<Value>(resultRef)->BooleanValue());
+  JsValueRef result;
+  if (JsDeleteProperty(this, idRef, false, &result) != JsNoError) {
+    return Nothing<bool>();
+  }
+
+  return Just(Local<Value>(result)->BooleanValue());
 }
 
 bool Object::Delete(Handle<Value> key) {


### PR DESCRIPTION
Many ObjectTemplate property callback handlings are not fully
v8-compatible. Noteably when a callback does not intercept (returns empty
handle), chakrashim should fallback to default JS behaviro. However most
of the shim code did not or did incorrectly. This change fixes them.

Also fixed Object::Has and Object::Delete issue. They only accepted normal
name types -- String/Symbol. Changed to use GetPropertyIdFromValue so they
accept other types, e.g. an Integer.
