### PR TITLE
chakrashim: better StackTrace API compat

### DIFF
--- a/deps/chakrashim/src/jsrtcontextshim.cc
+++ b/deps/chakrashim/src/jsrtcontextshim.cc
@@ -437,7 +437,7 @@ bool ContextShim::ExecuteChakraShimJS() {
     return false;
   }
   JsValueRef result;
-  JsValueRef arguments[] = { this->keepAliveObject };
+  JsValueRef arguments[] = { this->globalObject, this->keepAliveObject };
   return JsCallFunction(initFunction, arguments, _countof(arguments),
                         &result) == JsNoError;
 }


### PR DESCRIPTION
chakrashim supports Error.captureStackTrace. However, many uses directly
call "new Error()" and expect the same capture/prepare StackTrace
mechanism.

This change patches known Error types in chakra_shim.js, so that they'd
go through similar capture/prepareStackTrace when constructors are called.

Fixed some corner case bugs around different Error.stackTraceLimit, and
when error.message or error.stack is undefined.
