### PR TITLE
address a list of failing tests for chakra

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -2350,12 +2350,14 @@ class V8_EXPORT TryCatch {
  private:
   friend class Function;
 
+  void SetNonUser() { user = false; }
   void GetAndClearException();
   void CheckReportExternalException();
 
   JsValueRef error;
   TryCatch* prev;
   bool rethrow;
+  bool user;
   bool verbose;
 };
 

--- a/deps/chakrashim/src/v8function.cc
+++ b/deps/chakrashim/src/v8function.cc
@@ -69,6 +69,7 @@ MaybeLocal<Value> Function::Call(Local<Context> context,
   JsValueRef result;
   {
     TryCatch tryCatch;
+    tryCatch.SetNonUser();
     if (JsCallFunction((JsValueRef)this, args, argc + 1,
                        &result) != JsNoError) {
       tryCatch.CheckReportExternalException();

--- a/deps/chakrashim/src/v8functiontemplate.cc
+++ b/deps/chakrashim/src/v8functiontemplate.cc
@@ -86,6 +86,10 @@ struct FunctionCallbackData {
                                              JsValueRef *arguments,
                                              unsigned short argumentCount,
                                              void *callbackState) {
+    // Script engine could have switched context. Make sure to invoke the
+    // callback in the current callee context.
+    ContextShim* contextShim = IsolateShim::GetContextShimOfObject(callee);
+    ContextShim::Scope contextScope(contextShim);
     HandleScope scope(nullptr);
 
     JsValueRef functionCallbackDataRef = JsValueRef(callbackState);

--- a/test/abort/test-abort-uncaught-exception.js
+++ b/test/abort/test-abort-uncaught-exception.js
@@ -5,6 +5,12 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const node = process.execPath;
 
+if (common.isChakraEngine) {
+  console.log(`1..0 # Skipped: This test is disabled for chakra engine
+    because it depends on v8-option --abort-on-uncaught-exception`);
+  return;
+}
+
 if (process.argv[2] === 'child') {
   throw new Error('child error');
 } else {

--- a/test/message/error_exit.chakracore.out
+++ b/test/message/error_exit.chakracore.out
@@ -6,3 +6,4 @@ AssertionError: 1 == 2
    at Module.prototype.load (module.js:*:*)
    at Module._load (module.js:*:*)
    at Module.runMain (module.js:*:*)
+   at startup (node.js:*:*)

--- a/test/message/eval_messages.chakracore.out
+++ b/test/message/eval_messages.chakracore.out
@@ -4,8 +4,8 @@ SyntaxError: 'with' statements are not allowed in strict mode
    at Anonymous function ([eval]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 42
 42
 Error: hello
@@ -14,16 +14,16 @@ Error: hello
    at Anonymous function ([eval]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 Error: hello
    at Global code ([eval]:1:15)
    at exports.runInThisContext (vm.js:*)
    at Anonymous function ([eval]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 100
 ReferenceError: Variable undefined in strict mode
    at Global code ([eval]:1:28)
@@ -31,8 +31,8 @@ ReferenceError: Variable undefined in strict mode
    at Anonymous function ([eval]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 10
 10
 done

--- a/test/message/nexttick_throw.chakracore.out
+++ b/test/message/nexttick_throw.chakracore.out
@@ -1,7 +1,7 @@
 ReferenceError: 'undefined_reference_error_maker' is undefined
    at Anonymous function (*test*message*nexttick_throw.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
    at Module.runMain (module.js:*:*)
    at startup (node.js:*:*)
    at Anonymous function (node.js:*:*)

--- a/test/message/stdin_messages.chakracore.out
+++ b/test/message/stdin_messages.chakracore.out
@@ -4,8 +4,8 @@ SyntaxError: 'with' statements are not allowed in strict mode
    at Anonymous function ([stdin]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 42
 42
 Error: hello
@@ -14,16 +14,16 @@ Error: hello
    at Anonymous function ([stdin]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 Error: hello
    at Global code ([stdin]:*)
    at exports.runInThisContext (vm.js:*)
    at Anonymous function ([stdin]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 100
 ReferenceError: Variable undefined in strict mode
    at Global code ([stdin]:*)
@@ -31,8 +31,8 @@ ReferenceError: Variable undefined in strict mode
    at Anonymous function ([stdin]-wrapper:*:*)
    at Module.prototype._compile (module.js:*:*)
    at Anonymous function (node.js:*:*)
-   at nextTickCallbackWith0Args (node.js:*:*)
-   at _tickCallback (node.js:*:*)
+   at _combinedTickCallback (internal/process/next_tick.js:*:*)
+   at _tickCallback (internal/process/next_tick.js:*:*)
 10
 10
 done

--- a/test/message/testcfg.py
+++ b/test/message/testcfg.py
@@ -134,7 +134,7 @@ class MessageTestConfiguration(test.TestConfiguration):
           if not exists(output_path):
             print "Could not find %s or %s" % (output_path, engine_output_path)
             continue
-          result.append(MessageTestCase(test, file_path, output_path,
+        result.append(MessageTestCase(test, file_path, output_path,
                                       arch, mode, self.context, self))
     return result
 

--- a/test/message/timeout_throw.chakracore.out
+++ b/test/message/timeout_throw.chakracore.out
@@ -1,3 +1,4 @@
 ReferenceError: 'undefined_reference_error_maker' is undefined
    at Anonymous function (*test*message*timeout_throw.js:*:*)
+   at tryOnTimeout (timers.js:*:*)
    at listOnTimeout (timers.js:*:*)

--- a/test/message/vm_display_runtime_error.chakracore.out
+++ b/test/message/vm_display_runtime_error.chakracore.out
@@ -1,0 +1,12 @@
+beginning
+Error: boo!
+   at Global code (test.vm:*)
+   at exports.runInThisContext (vm.js:*)
+   at Anonymous function (*test*message*vm_display_runtime_error.js:*)
+   at Module.prototype._compile (module.js:*)
+   at Module._extensions[.js] (module.js:*)
+   at Module.prototype.load (module.js:*)
+   at Module._load (module.js:*)
+   at Module.runMain (module.js:*)
+   at startup (node.js:*)
+   at Anonymous function (node.js:*)

--- a/test/message/vm_dont_display_runtime_error.chakracore.out
+++ b/test/message/vm_dont_display_runtime_error.chakracore.out
@@ -1,0 +1,13 @@
+beginning
+middle
+Error: boo!
+   at Global code (test.vm:*)
+   at exports.runInThisContext (vm.js:*)
+   at Anonymous function (*test*message*vm_dont_display_runtime_error.js:*)
+   at Module.prototype._compile (module.js:*)
+   at Module._extensions[.js] (module.js:*)
+   at Module.prototype.load (module.js:*)
+   at Module._load (module.js:*)
+   at Module.runMain (module.js:*)
+   at startup (node.js:*)
+   at Anonymous function (node.js:*)

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -967,9 +967,14 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
 // Call .fill() first, stops valgrind warning about uninitialized memory reads.
 Buffer.allocUnsafe(3.3).fill().toString();
   // throws bad argument error in commit 43cb4ec
-Buffer.alloc(3.3).fill().toString();
+Buffer.alloc(common.engineSpecificMessage({
+  v8: 3.3,
+  chakracore: Math.trunc(3.3)})) // new Uint8Array(3.3) throws
+  .fill().toString();
 assert.equal(Buffer.allocUnsafe(-1).length, 0);
-assert.equal(Buffer.allocUnsafe(NaN).length, 0);
+if (!common.isChakraEngine) { // Skip on chakra, new Uint8Array(NaN) throws
+  assert.equal(Buffer.allocUnsafe(NaN).length, 0);
+}
 assert.equal(Buffer.allocUnsafe(3.3).length, 3);
 assert.equal(Buffer.from({length: 3.3}).length, 3);
 assert.equal(Buffer.from({length: 'BAM'}).length, 0);

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var zero = [];
@@ -23,7 +23,9 @@ assert(flatLongLen.toString() === (new Array(10 + 1).join('asdf')));
 assertWrongList();
 assertWrongList(null);
 assertWrongList(Buffer.from('hello'));
-assertWrongList([42]);
+if (!common.isChakraEngine) { // Skip on chakra, new Uint8Array(NaN) throws
+  assertWrongList([42]);
+}
 assertWrongList(['hello', 'world']);
 assertWrongList(['hello', Buffer.from('world')]);
 

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -960,7 +960,9 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 // Call .fill() first, stops valgrind warning about uninitialized memory reads.
 Buffer(3.3).fill().toString(); // throws bad argument error in commit 43cb4ec
 assert.equal(Buffer(-1).length, 0);
-assert.equal(Buffer(NaN).length, 0);
+if (!common.isChakraEngine) { // Skip on chakra, new Uint8Array(NaN) throws
+  assert.equal(Buffer(NaN).length, 0);
+}
 assert.equal(Buffer(3.3).length, 3);
 assert.equal(Buffer({length: 3.3}).length, 3);
 assert.equal(Buffer({length: 'BAM'}).length, 0);

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -9,6 +9,12 @@ const assert = require('assert');
 const domain = require('domain');
 const child_process = require('child_process');
 
+if (common.isChakraEngine) {
+  console.log(`1..0 # Skipped: This test is disabled for chakra engine
+    because it depends on v8-option --abort-on-uncaught-exception`);
+  return;
+}
+
 var errorHandlerCalled = false;
 
 const tests = [

--- a/test/parallel/test-domain-no-error-handler-abort-on-uncaught.js
+++ b/test/parallel/test-domain-no-error-handler-abort-on-uncaught.js
@@ -10,6 +10,12 @@ const assert = require('assert');
 const domain = require('domain');
 const child_process = require('child_process');
 
+if (common.isChakraEngine) {
+  console.log(`1..0 # Skipped: This test is disabled for chakra engine
+    because it depends on v8-option --abort-on-uncaught-exception`);
+  return;
+}
+
 const tests = [
   function() {
     const d = domain.create();

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -10,6 +10,12 @@ const assert = require('assert');
 const child_process = require('child_process');
 const domain = require('domain');
 
+if (common.isChakraEngine) {
+  console.log(`1..0 # Skipped: This test is disabled for chakra engine
+    because it depends on v8-option --abort-on-uncaught-exception`);
+  return;
+}
+
 const uncaughtExceptionHandlerErrMsg = 'boom from uncaughtException handler';
 const domainErrMsg = 'boom from domain';
 

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -26,6 +26,12 @@ const common = require('../common');
  * not --abort_on_uncaught_exception is passed on the command line.
  */
 
+if (common.isChakraEngine) {
+  console.log(`1..0 # Skipped: This test is disabled for chakra engine
+    because it depends on v8-option --abort-on-uncaught-exception`);
+  return;
+}
+
 const domainErrHandlerExMessage = 'exception from domain error handler';
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -18,8 +18,10 @@ function errExec(script, callback) {
       assert.ok(stderr.split('\n').length > 2);
     }
 
-    // Assert the script is mentioned in error output.
-    assert.ok(stderr.indexOf(script) >= 0);
+    if (!common.isChakraEngine) { // chakra does not output script
+      // Assert the script is mentioned in error output.
+      assert.ok(stderr.indexOf(script) >= 0);
+    }
 
     // Proxy the args for more tests.
     callback(err, stdout, stderr);
@@ -50,7 +52,9 @@ errExec('throws_error3.js', function(err, stdout, stderr) {
 
 // throw ILLEGAL error
 errExec('throws_error4.js', function(err, stdout, stderr) {
-  assert.ok(/\/\*\*/.test(stderr));
+  if (!common.isChakraEngine) { // chakra does not output source line
+    assert.ok(/\/\*\*/.test(stderr));
+  }
   assert.ok(/SyntaxError/.test(stderr));
 });
 

--- a/test/parallel/test-fs-read-buffer-tostring-fail.js
+++ b/test/parallel/test-fs-read-buffer-tostring-fail.js
@@ -17,7 +17,10 @@ const stream = fs.createWriteStream(file, {
 });
 
 const size = kStringMaxLength / 200;
-const a = Buffer.alloc(common.isChakraEngine ? Math.round(size) : size).fill('a');
+const a = Buffer.alloc(common.engineSpecificMessage({
+  v8: size,
+  chakracore: Math.trunc(size)
+})).fill('a');
 
 for (var i = 0; i < 201; i++) {
   stream.write(a);

--- a/test/parallel/test-fs-readfile-tostring-fail.js
+++ b/test/parallel/test-fs-readfile-tostring-fail.js
@@ -14,7 +14,8 @@ const stream = fs.createWriteStream(file, {
 });
 
 const size = kStringMaxLength / 200;
-const a = Buffer.alloc(common.isChakraEngine ? Math.round(size) : size).fill('a');
+const a = Buffer.alloc(
+  common.isChakraEngine ? Math.trunc(size) : size).fill('a');
 
 for (var i = 0; i < 201; i++) {
   stream.write(a);
@@ -24,6 +25,9 @@ stream.end();
 stream.on('finish', common.mustCall(function() {
   // make sure that the toString does not throw an error
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
+    if (common.isChakraEngine) { // chakra does not fail at this limit
+      return;
+    }
     assert.ok(err instanceof Error);
     assert.strictEqual('"toString()" failed', err.message);
   }));

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -60,14 +60,21 @@ if (!haveIntl) {
 
   // Check with toLocaleString
   var localeString = dtf.format(date0);
-  assert.equal(localeString, 'Jan 70');
+  assert.equal(localeString, common.engineSpecificMessage({
+    v8: 'Jan 70',
+    chakracore: '\u200EJan\u200E \u200E70'
+  }));
 
   // Options to request GMT
   var optsGMT = {timeZone: GMT};
 
   // Test format
   localeString = date0.toLocaleString(['en'], optsGMT);
-  assert.equal(localeString, '1/1/1970, 12:00:00 AM');
+  assert.equal(localeString, common.engineSpecificMessage({
+    v8: '1/1/1970, 12:00:00 AM',
+    chakracore: '\u200E1\u200E/\u200E1\u200E/\u200E1970\u200E '
+      + '\u200E12\u200E:\u200E00\u200E:\u200E00\u200E \u200EAM'
+  }));
 
   // number format
   assert.equal(new Intl.NumberFormat(['en']).format(12345.67890), '12,345.679');

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -11,7 +11,10 @@ process.on('exit', () => {
 });
 
 common.ArrayStream.prototype.write = function(output) {
-  if (/var foo bar;/.test(output))
+  if (common.engineSpecificMessage({
+    v8: /var foo bar;/,
+    chakracore: /Expected ';'/  // chakra does not show source
+  }).test(output))
     found = true;
 };
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -49,7 +49,10 @@ function clean_up() {
 function strict_mode_error_test() {
   send_expect([
     { client: client_unix, send: 'ref = 1',
-      expect: /^ReferenceError:\sref\sis\snot\sdefined\n\s+at\srepl:1:5/ },
+      expect: common.engineSpecificMessage({
+        v8: /^ReferenceError:\sref\sis\snot\sdefined\n\s+at\srepl:1:5/,
+        chakracore: /^ReferenceError: Variable undefined in strict mode/
+      })},
   ]);
 }
 
@@ -237,11 +240,14 @@ function error_test() {
       expect: '1' },
     // Multiline function call
     { client: client_unix, send: 'function f(){}; f(f(1,',
-      expect: prompt_multiline },
+      expect: prompt_multiline,
+      chakracore: 'https://github.com/Microsoft/ChakraCore/issues/767' },
     { client: client_unix, send: '2)',
-      expect: prompt_multiline },
+      expect: prompt_multiline,
+      chakracore: 'skip' },
     { client: client_unix, send: ')',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\n' + prompt_unix,
+      chakracore: 'skip' },
     // npm prompt error message
     { client: client_unix, send: 'npm install foobar',
       expect: expect_npm },
@@ -362,7 +368,7 @@ function error_test() {
             'undefined\n' + prompt_unix },
     { client: client_unix, send: '{ var x = 4; }',
       expect: 'undefined\n' + prompt_unix },
-  ]);
+  ].filter((v) => !common.engineSpecificMessage(v)));
 }
 
 function tcp_test() {

--- a/test/parallel/test-util-decorate-error-stack.js
+++ b/test/parallel/test-util-decorate-error-stack.js
@@ -1,6 +1,6 @@
 // Flags: --expose_internals
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 const spawnSync = require('child_process').spawnSync;
@@ -20,7 +20,10 @@ assert.strictEqual(obj.stack, undefined);
 
 // Verify that the stack is decorated when possible
 function checkStack(stack) {
-  const matches = stack.match(/var foo bar;/g);
+  const matches = stack.match(common.engineSpecificMessage({
+    v8: /var foo bar;/g,
+    chakracore: /Expected ';'/g  // chakra does not show source
+  }));
   assert.strictEqual(Array.isArray(matches), true);
   assert.strictEqual(matches.length, 1);
 }

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -1,7 +1,7 @@
 'use strict';
 // Flags: --expose_internals
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 const spawnSync = require('child_process').spawnSync;
@@ -48,7 +48,9 @@ try {
   arrowMessage = internalUtil.getHiddenValue(err, 'node:arrowMessage');
 }
 
-assert(/bad_syntax\.js:1/.test(arrowMessage));
+if (!common.isChakraEngine) {  // chakra does not show script/source
+  assert(/bad_syntax\.js:1/.test(arrowMessage));
+}
 
 const args = [
   '--expose-internals',


### PR DESCRIPTION
This PR contains 2 fixes in chakrashim and a list of test patches.

Reduced outstanding test failures on node-chakracore from ~39 to ~16.

Diffing with my chakracore-master_20160406 log:

```
InputObject                                                                 SideIndicator
-----------                                                                 -------------
addons/load-long-path/test                                                  =>
addons/repl-domain-abort/test                                               <=
message/vm_display_runtime_error                                            <=
message/vm_dont_display_runtime_error                                       <=
parallel/test-async-wrap-throw-from-callback                                <=
parallel/test-buffer                                                        <=
parallel/test-buffer-alloc                                                  <=
parallel/test-buffer-concat                                                 <=
parallel/test-buffer-includes                                               <=
parallel/test-buffer-indexof                                                <=
parallel/test-child-process-flush-stdio                                     <=
parallel/test-domain-abort-on-uncaught                                      <=
parallel/test-domain-no-error-handler-abort-on-uncaught                     <=
parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler <=
parallel/test-domain-with-abort-on-uncaught-exception                       <=
parallel/test-error-reporting                                               <=
parallel/test-fs-readfile-tostring-fail                                     <=
parallel/test-intl                                                          <=
parallel/test-regress-GH-io-1068                                            <=
parallel/test-repl                                                          <=
parallel/test-repl-require                                                  <=
parallel/test-repl-syntax-error-stack                                       <=
parallel/test-util-decorate-error-stack                                     <=
parallel/test-util-internal                                                 <=
sequential/test-regress-GH-746                                              <=
```
