### PR TITLE
chakrashim: remove dependency inputs linker option

### DIFF
--- a/deps/chakrashim/chakrashim.gyp
+++ b/deps/chakrashim/chakrashim.gyp
@@ -34,7 +34,6 @@
           ],
         }],
       ],
-      'msvs_use_library_dependency_inputs': 1,
 
       'direct_dependent_settings': {
         'include_dirs': [


### PR DESCRIPTION
##### Checklist
- [ x] the commit message follows commit guidelines
##### Affected core subsystem(s)

chakrashim
##### Description of change

msvs_use_library_dependency_inputs is a no-op for this project.
Also the variable will be going away eventually in gyp since
'UseLibraryDependencyInputs' (which does the same thing) already
exists.
