### PR TITLE
Trigger GC when idle

### DIFF
--- a/deps/chakrashim/chakrashim.gyp
+++ b/deps/chakrashim/chakrashim.gyp
@@ -16,7 +16,8 @@
 
       'include_dirs': [
         'include',
-        '<(SHARED_INTERMEDIATE_DIR)'
+        '<(SHARED_INTERMEDIATE_DIR)',
+        './../uv/include'
       ],
       'defines': [
         'BUILDING_CHAKRASHIM=1',

--- a/deps/chakrashim/src/jsrtcontextshim.cc
+++ b/deps/chakrashim/src/jsrtcontextshim.cc
@@ -397,6 +397,11 @@ bool ContextShim::EnsureInitialized() {
     return false;
   }
 
+  // add idleGC callback into prepareQueue
+  if (IsolateShim::IsIdleGcEnabled()) {
+    uv_prepare_start(IsolateShim::GetCurrent()->idleGc_prepare_handle(), PrepareIdleGC);
+  }
+
   return true;
 }
 

--- a/deps/chakrashim/src/jsrtutils.h
+++ b/deps/chakrashim/src/jsrtutils.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "v8.h"
+#include "uv.h"
 #include "jsrtproxyutils.h"
 #include "jsrtcontextshim.h"
 #include "jsrtisolateshim.h"
@@ -324,6 +325,12 @@ void Unimplemented(const char * message);
 
 void Fatal(const char * format, ...);
 
+void ScheduleIdleGcTask(uint64_t timeoutInMilliSeconds = 1000);
+
+void PrepareIdleGC(uv_prepare_t* prepareHandler);
+
+void IdleGC(uv_timer_t *timerHandler);
+
 // Arguments buffer for JsCallFunction
 template <int STATIC_COUNT = 4>
 class JsArguments {
@@ -451,5 +458,6 @@ inline JsErrorCode ValueToDoubleLikely(JsValueRef value, double* dblValue) {
   return ValueToNative</*LIKELY*/true>(
     JsConvertValueToNumber, JsNumberToDouble, value, dblValue);
 }
+
 }  // namespace jsrt
 

--- a/deps/chakrashim/src/v8function.cc
+++ b/deps/chakrashim/src/v8function.cc
@@ -59,6 +59,8 @@ Local<Object> Function::NewInstance() const {
 MaybeLocal<Value> Function::Call(Local<Context> context,
                                  Handle<Value> recv, int argc,
                                  Handle<Value> argv[]) {
+  IsolateShim::GetCurrent()->SetScriptExecuted();
+
   jsrt::JsArguments<> args(argc + 1);
   args[0] = *recv;
 

--- a/deps/chakrashim/src/v8isolate.cc
+++ b/deps/chakrashim/src/v8isolate.cc
@@ -191,13 +191,13 @@ void Isolate::GetHeapStatistics(HeapStatistics *heap_statistics) {
 }
 
 size_t Isolate::NumberOfHeapSpaces() {
-  //Chakra doesn't expose HEAP space stats
+  // Chakra doesn't expose HEAP space stats
   return 0;
 }
 
 bool Isolate::GetHeapSpaceStatistics(HeapSpaceStatistics* space_statistics,
                                      size_t index) {
-  //Chakra doesn't expose HEAP space stats
+  // Chakra doesn't expose HEAP space stats
   return true;
 }
 

--- a/deps/chakrashim/src/v8script.cc
+++ b/deps/chakrashim/src/v8script.cc
@@ -101,6 +101,8 @@ Local<Script> Script::Compile(Handle<String> source,
 }
 
 MaybeLocal<Value> Script::Run(Local<Context> context) {
+  jsrt::IsolateShim::GetCurrent()->SetScriptExecuted();
+
   JsValueRef scriptFunction;
   if (jsrt::GetProperty(this, CachedPropertyIdRef::function,
                         &scriptFunction) != JsNoError) {

--- a/node.gyp
+++ b/node.gyp
@@ -721,7 +721,10 @@
           ],
         }],
         ['node_engine=="chakracore"', {
-          'dependencies': [ 'deps/chakrashim/chakrashim.gyp:chakrashim' ],
+          'dependencies': [ 
+             'deps/chakrashim/chakrashim.gyp:chakrashim',
+             'deps/uv/uv.gyp:libuv'
+          ],
         }],
       ],
       'msvs_settings': {

--- a/src/node.cc
+++ b/src/node.cc
@@ -4409,9 +4409,9 @@ static void StartNodeInstance(void* arg) {
       do {
         v8::platform::PumpMessageLoop(default_platform, isolate);
         more = uv_run(env->event_loop(), UV_RUN_ONCE);
-
         if (more == false) {
           v8::platform::PumpMessageLoop(default_platform, isolate);
+
           EmitBeforeExit(env);
 
           // Emit `beforeExit` if the loop became alive either after emitting


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

deps,src
##### Description of change

<!-- provide a description of the change below this comment -->

Chakracore has [JsIdle](https://github.com/Microsoft/ChakraCore/wiki/JsIdle) API that a host can trigger to perform memory cleanp tasks whenever it is idle. In order to achieve this added a scheduler that will schedule idle GC in [prepare queue](http://docs.libuv.org/en/v1.x/prepare.html) after 1 second the last script execution started. When there are no more scripts to execute, task in `prepare queue` would get executed which will trigger `JsIdle`. `JsIdle` returns tickCount until there will be more idle work to do. It can also return maximum tickCount that signifies that there is no idle work to perform. Based on the return value of this API, decide whether there is a need
to reschedule another `JsIdle` or not.

With this implementation chakrashim takes dependency on `libuv`.
