### PR TITLE
win,node-gyp: work around __pfnDliNotifyHook2 type change

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -41,7 +41,7 @@
         'conditions': [
           [ 'OS=="win"', {
             'sources': [
-              '<(node_gyp_dir)/src/win_delay_load_hook.c',
+              '<(node_gyp_dir)/src/win_delay_load_hook.cc',
             ],
             'msvs_settings': {
               'VCLinkerTool': {

--- a/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.cc
+++ b/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.cc
@@ -31,6 +31,6 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   return (FARPROC) m;
 }
 
-PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 
 #endif


### PR DESCRIPTION
This pulls following fix from upstream to support VS2015 update 3:

https://github.com/nodejs/node-gyp/commit/f31482e2260e3beb90d959c62135e5e95c06ed4d
