### PR TITLE
Enable/Disable ES6 experimental features in chakracore using compile flags

### DIFF
--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -50,6 +50,7 @@
             '/p:Platform=<(Platform)',
             '/p:Configuration=$(ConfigurationName)',
             '/p:RuntimeLib=<(component)',
+            '/p:AdditionalPreprocessorDefinitions=COMPILE_DISABLE_Simdjs=1',
             '<(msvs_windows_target_platform_version_prop)',
             '/m',
             '<@(_inputs)',

--- a/deps/chakrashim/core/Build/Common.Build.props
+++ b/deps/chakrashim/core/Build/Common.Build.props
@@ -9,6 +9,9 @@
 
       <PreprocessorDefinitions Condition="'$(RuntimeLib)'=='static_library'">%(PreprocessorDefinitions);USE_STATIC_RUNTIMELIB</PreprocessorDefinitions>
 
+      <!-- Add any preprocessor definitions passed using msbuild environment -->
+      <PreprocessorDefinitions Condition="'$(AdditionalPreprocessorDefinitions)'!=''">%(PreprocessorDefinitions);$(AdditionalPreprocessorDefinitions)</PreprocessorDefinitions>
+      
       <!-- /W4 -->
       <WarningLevel>Level4</WarningLevel>
       <!-- /WX -->

--- a/deps/chakrashim/core/lib/Runtime/Base/ThreadContext.cpp
+++ b/deps/chakrashim/core/lib/Runtime/Base/ThreadContext.cpp
@@ -99,7 +99,7 @@ ThreadContext::RecyclableData::RecyclableData(Recycler *const recycler) :
 #define ALLOC_XDATA (false)
 #endif
 
-ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, JsUtil::ThreadService::ThreadServiceCallback threadServiceCallback, bool enableExperimentalFeatures, bool enableSimdjsFeature) :
+ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, JsUtil::ThreadService::ThreadServiceCallback threadServiceCallback, bool enableExperimentalFeatures) :
     currentThreadId(::GetCurrentThreadId()),
     stackLimitForCurrentThread(0),
     stackProber(nullptr),
@@ -176,7 +176,7 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     dynamicObjectEnumeratorCacheMap(&HeapAllocator::Instance, 16),
     //threadContextFlags(ThreadContextFlagNoFlag),
     telemetryBlock(&localTelemetryBlock),
-    configuration(enableExperimentalFeatures, enableSimdjsFeature),
+    configuration(enableExperimentalFeatures),
     jsrtRuntime(nullptr),
     rootPendingClose(nullptr),
     wellKnownHostTypeHTMLAllCollectionTypeId(Js::TypeIds_Undefined),

--- a/deps/chakrashim/core/lib/Runtime/Base/ThreadContext.h
+++ b/deps/chakrashim/core/lib/Runtime/Base/ThreadContext.h
@@ -309,13 +309,12 @@ public:
 class ThreadConfiguration
 {
 public:
-    ThreadConfiguration(bool enableExperimentalFeatures, bool enableSimdjsFeature)
+    ThreadConfiguration(bool enableExperimentalFeatures)
     {
         CopyGlobalFlags();
         if (enableExperimentalFeatures)
         {
             EnableExperimentalFeatures();
-            m_Simdjs = enableSimdjsFeature;
         }
     }
 
@@ -1005,7 +1004,7 @@ public:
     ArenaAllocator* GetThreadAlloc() { return &threadAlloc; }
     static CriticalSection * GetCriticalSection() { return &s_csThreadContext; }
 
-    ThreadContext(AllocationPolicyManager * allocationPolicyManager = nullptr, JsUtil::ThreadService::ThreadServiceCallback threadServiceCallback = nullptr, bool enableExperimentalFeatures = false, bool enableSimdjsFeature = false);
+    ThreadContext(AllocationPolicyManager * allocationPolicyManager = nullptr, JsUtil::ThreadService::ThreadServiceCallback threadServiceCallback = nullptr, bool enableExperimentalFeatures = false);
     static void Add(ThreadContext *threadContext);
 
     ThreadConfiguration const * GetConfig() const { return &configuration; }

--- a/deps/chakrashim/core/lib/Runtime/Base/ThreadContext.h
+++ b/deps/chakrashim/core/lib/Runtime/Base/ThreadContext.h
@@ -315,6 +315,7 @@ public:
         if (enableExperimentalFeatures)
         {
             EnableExperimentalFeatures();
+            ResetExperimentalFeaturesFromConfig();
         }
     }
 
@@ -345,7 +346,16 @@ private:
 
     void EnableExperimentalFeatures()
     {
-#define FLAG_REGOVR_EXP(type, name, ...) m_##name## = true;
+        // If a ES6 flag is disabled using compile flag don't enable it
+#define FLAG_REGOVR_EXP(type, name, ...) m_##name## = COMPILE_DISABLE_##name## ? false : true;
+#include "ConfigFlagsList.h"
+#undef FLAG_REGOVR_EXP
+    }
+
+    void ResetExperimentalFeaturesFromConfig()
+    {
+        // If a flag was overridden using config/command line it should take precedence
+#define FLAG_REGOVR_EXP(type, name, ...) if(CONFIG_ISENABLED(Js::Flag::##name##Flag)) { m_##name## = CONFIG_FLAG_RELEASE(##name##); }
 #include "ConfigFlagsList.h"
 #undef FLAG_REGOVR_EXP
     }

--- a/deps/chakrashim/core/lib/common/ConfigFlagsList.h
+++ b/deps/chakrashim/core/lib/common/ConfigFlagsList.h
@@ -355,7 +355,12 @@ PHASE(All)
 #define DEFAULT_CONFIG_ASMJS                (true)
 #define DEFAULT_CONFIG_AsmJsEdge            (false)
 #define DEFAULT_CONFIG_AsmJsStopOnError     (false)
-#define DEFAULT_CONFIG_SIMDJS               (false)
+#ifdef COMPILE_DISABLE_Simdjs
+    // If Simdjs needs to be disabled by compile flag, DEFAULT_CONFIG_SIMDJS should be false
+    #define DEFAULT_CONFIG_SIMDJS               (false)
+#else
+    #define DEFAULT_CONFIG_SIMDJS               (false)
+#endif
 #define DEFAULT_CONFIG_BgJitDelayFgBuffer   (0)
 #define DEFAULT_CONFIG_BgJitPendingFuncCap  (31)
 #define DEFAULT_CONFIG_CurrentSourceInfo     (true)
@@ -479,15 +484,35 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6Classes              (true)
 #define DEFAULT_CONFIG_ES6DateParseFix         (true)
 #define DEFAULT_CONFIG_ES6DefaultArgs          (true)
-#define DEFAULT_CONFIG_ES6DefaultArgsSplitScope (false)
+#ifdef COMPILE_DISABLE_ES6DefaultArgsSplitScope
+    // If ES6DefaultArgsSplitScope needs to be disabled by compile flag, COMPILE_DISABLE_ES6DefaultArgsSplitScope should be false
+    #define DEFAULT_CONFIG_ES6DefaultArgsSplitScope (false)
+#else
+    #define DEFAULT_CONFIG_ES6DefaultArgsSplitScope (false)
+#endif
 #define DEFAULT_CONFIG_ES6Destructuring        (true)
 #define DEFAULT_CONFIG_ES6ForLoopSemantics     (true)
 #define DEFAULT_CONFIG_ES6FunctionName         (true)
-#define DEFAULT_CONFIG_ES6FunctionNameFull     (false)
+#ifdef COMPILE_DISABLE_ES6FunctionNameFull
+    // If ES6FunctionNameFull needs to be disabled by compile flag, COMPILE_DISABLE_ES6FunctionNameFull should be false
+    #define DEFAULT_CONFIG_ES6FunctionNameFull     (false)
+#else
+    #define DEFAULT_CONFIG_ES6FunctionNameFull     (false)
+#endif
 #define DEFAULT_CONFIG_ES6Generators           (true)
-#define DEFAULT_CONFIG_ES6IsConcatSpreadable   (false)
+#ifdef COMPILE_DISABLE_ES6IsConcatSpreadable
+    // If ES6IsConcatSpreadable needs to be disabled by compile flag, COMPILE_DISABLE_ES6IsConcatSpreadable should be false
+    #define DEFAULT_CONFIG_ES6IsConcatSpreadable   (false)
+#else
+    #define DEFAULT_CONFIG_ES6IsConcatSpreadable   (false)
+#endif
 #define DEFAULT_CONFIG_ES6Math                 (true)
-#define DEFAULT_CONFIG_ES6Module               (false)
+#ifdef COMPILE_DISABLE_ES6Module
+    // If ES6Module needs to be disabled by compile flag, DEFAULT_CONFIG_ES6Module should be false
+    #define DEFAULT_CONFIG_ES6Module               (false)
+#else
+    #define DEFAULT_CONFIG_ES6Module               (false)
+#endif
 #define DEFAULT_CONFIG_ES6Object               (true)
 #define DEFAULT_CONFIG_ES6Number               (true)
 #define DEFAULT_CONFIG_ES6ObjectLiterals       (true)
@@ -497,7 +522,12 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6Spread               (true)
 #define DEFAULT_CONFIG_ES6String               (true)
 #define DEFAULT_CONFIG_ES6StringPrototypeFixes (true)
-#define DEFAULT_CONFIG_ES6PrototypeChain       (false)
+#ifdef COMPILE_DISABLE_ES6PrototypeChain
+    // If ES6PrototypeChain needs to be disabled by compile flag, DEFAULT_CONFIG_ES6PrototypeChain should be false
+    #define DEFAULT_CONFIG_ES6PrototypeChain       (false)
+#else
+    #define DEFAULT_CONFIG_ES6PrototypeChain       (false)
+#endif
 #define DEFAULT_CONFIG_ES6ToPrimitive          (false)
 #define DEFAULT_CONFIG_ES6ToLength             (false)
 #define DEFAULT_CONFIG_ES6ToStringTag          (false)
@@ -506,12 +536,37 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6UnicodeVerbose       (true)
 #define DEFAULT_CONFIG_ES6Unscopables          (true)
 #define DEFAULT_CONFIG_ES6RegExSticky          (true)
-#define DEFAULT_CONFIG_ES6RegExPrototypeProperties (false)
-#define DEFAULT_CONFIG_ES6RegExSymbols         (false)
+#ifdef COMPILE_DISABLE_ES6RegExPrototypeProperties
+    // If ES6RegExPrototypeProperties needs to be disabled by compile flag, DEFAULT_CONFIG_ES6RegExPrototypeProperties should be false
+    #define DEFAULT_CONFIG_ES6RegExPrototypeProperties (false)
+#else
+    #define DEFAULT_CONFIG_ES6RegExPrototypeProperties (false)
+#endif
+#ifdef COMPILE_DISABLE_ES6RegExSymbols
+    // If ES6RegExSymbols needs to be disabled by compile flag, DEFAULT_CONFIG_ES6RegExSymbols should be false
+    #define DEFAULT_CONFIG_ES6RegExSymbols         (false)
+#else
+    #define DEFAULT_CONFIG_ES6RegExSymbols         (false)
+#endif
 #define DEFAULT_CONFIG_ES6HasInstanceOf        (false)
-#define DEFAULT_CONFIG_ArrayBufferTransfer     (false)
-#define DEFAULT_CONFIG_ES7AsyncAwait           (false)
-#define DEFAULT_CONFIG_ES7Builtins             (false)
+#ifdef COMPILE_DISABLE_ArrayBufferTransfer
+    // If ArrayBufferTransfer needs to be disabled by compile flag, DEFAULT_CONFIG_ArrayBufferTransfer should be false
+    #define DEFAULT_CONFIG_ArrayBufferTransfer     (false)
+#else
+    #define DEFAULT_CONFIG_ArrayBufferTransfer     (false)
+#endif
+#ifdef COMPILE_DISABLE_ES7AsyncAwait
+    // If ES7AsyncAwait needs to be disabled by compile flag, DEFAULT_CONFIG_ES7AsyncAwait should be false
+    #define DEFAULT_CONFIG_ES7AsyncAwait           (false)
+#else
+    #define DEFAULT_CONFIG_ES7AsyncAwait           (false)
+#endif
+#ifdef COMPILE_DISABLE_ES7Builtins
+    // If ES7Builtins needs to be disabled by compile flag, DEFAULT_CONFIG_ES7Builtins should be false
+    #define DEFAULT_CONFIG_ES7Builtins             (false)
+#else
+    #define DEFAULT_CONFIG_ES7Builtins             (false)
+#endif
 #define DEFAULT_CONFIG_ES7ExponentionOperator  (true)
 #define DEFAULT_CONFIG_ES7TrailingComma        (true)
 #define DEFAULT_CONFIG_ES7ValuesEntries        (true)
@@ -750,6 +805,9 @@ FLAGR (Boolean, Asmjs                 , "Enable Asmjs", DEFAULT_CONFIG_ASMJS)
 FLAGNR(Boolean, AsmJsStopOnError      , "Stop execution on any AsmJs validation errors", DEFAULT_CONFIG_AsmJsStopOnError)
 FLAGNR(Boolean, AsmJsEdge             , "Enable asm.js features which may have backward incompatible changes or not validate on old demos", DEFAULT_CONFIG_AsmJsEdge)
 
+#ifndef COMPILE_DISABLE_Simdjs
+    #define COMPILE_DISABLE_Simdjs 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, Simdjs, "Enable Simdjs", DEFAULT_CONFIG_SIMDJS)
 FLAGR(Boolean, Simd128TypeSpec, "Enable type-specialization of Simd128 symbols", false)
 
@@ -862,22 +920,42 @@ FLAGNRC(Boolean, ES6Experimental           , "Enable all experimental features",
 // Per ES6 feature/flag
 
 FLAGPR           (Boolean, ES6, ES6Species             , "Enable ES6 '@@species' properties and built-in behaviors" , DEFAULT_CONFIG_ES6Species)
+
+#ifndef COMPILE_DISABLE_ES7AsyncAwait
+    #define COMPILE_DISABLE_ES7AsyncAwait 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES7AsyncAwait          , "Enable ES7 'async' and 'await' keywords"                  , DEFAULT_CONFIG_ES7AsyncAwait)
 FLAGPR           (Boolean, ES6, ES6Classes             , "Enable ES6 'class' and 'extends' keywords"                , DEFAULT_CONFIG_ES6Classes)
 FLAGPR           (Boolean, ES6, ES6DateParseFix        , "Enable ES6 Date.parse fixes"                              , DEFAULT_CONFIG_ES6DateParseFix)
 FLAGPR           (Boolean, ES6, ES6DefaultArgs         , "Enable ES6 Default Arguments"                             , DEFAULT_CONFIG_ES6DefaultArgs)
+
+#ifndef COMPILE_DISABLE_ES6DefaultArgsSplitScope
+    #define COMPILE_DISABLE_ES6DefaultArgsSplitScope 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES6DefaultArgsSplitScope, "Enable ES6 Default Arguments to have its own scope"      , DEFAULT_CONFIG_ES6DefaultArgsSplitScope)
 FLAGPR           (Boolean, ES6, ES6Destructuring       , "Enable ES6 Destructuring"                                 , DEFAULT_CONFIG_ES6Destructuring)
 FLAGPR           (Boolean, ES6, ES6ForLoopSemantics    , "Enable ES6 for loop per iteration bindings"               , DEFAULT_CONFIG_ES6ForLoopSemantics)
 FLAGPR           (Boolean, ES6, ES6FunctionName        , "Enable ES6 function.name"                                 , DEFAULT_CONFIG_ES6FunctionName)
+
+#ifndef COMPILE_DISABLE_ES6FunctionNameFull
+    #define COMPILE_DISABLE_ES6FunctionNameFull 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES6FunctionNameFull    , "Enable ES6 Full function.name"                            , DEFAULT_CONFIG_ES6FunctionNameFull)
 FLAGPR           (Boolean, ES6, ES6Generators          , "Enable ES6 generators"                                    , DEFAULT_CONFIG_ES6Generators)
 FLAGPR           (Boolean, ES6, ES7ExponentiationOperator, "Enable ES7 exponentiation operator (**)"                , DEFAULT_CONFIG_ES7ExponentionOperator)
+
+#ifndef COMPILE_DISABLE_ES7Builtins
+    #define COMPILE_DISABLE_ES7Builtins 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES7Builtins            , "Enable ES7 built-ins"                                     , DEFAULT_CONFIG_ES7Builtins)
 FLAGPR           (Boolean, ES6, ES7ValuesEntries       , "Enable ES7 Object.values and Object.entries"              , DEFAULT_CONFIG_ES7ValuesEntries)
 FLAGPR           (Boolean, ES6, ES7TrailingComma       , "Enable ES7 trailing comma in function"                    , DEFAULT_CONFIG_ES7TrailingComma)
 FLAGPR           (Boolean, ES6, ES6IsConcatSpreadable  , "Enable ES6 isConcatSpreadable Symbol"                     , DEFAULT_CONFIG_ES6IsConcatSpreadable)
 FLAGPR           (Boolean, ES6, ES6Math                , "Enable ES6 Math extensions"                               , DEFAULT_CONFIG_ES6Math)
+
+#ifndef COMPILE_DISABLE_ES6Module
+    #define COMPILE_DISABLE_ES6Module 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES6Module              , "Enable ES6 Modules"                                       , DEFAULT_CONFIG_ES6Module)
 FLAGPR           (Boolean, ES6, ES6Object              , "Enable ES6 Object extensions"                             , DEFAULT_CONFIG_ES6Object)
 FLAGPR           (Boolean, ES6, ES6Number              , "Enable ES6 Number extensions"                             , DEFAULT_CONFIG_ES6Number)
@@ -888,6 +966,10 @@ FLAGPR           (Boolean, ES6, ES6Rest                , "Enable ES6 Rest parame
 FLAGPR           (Boolean, ES6, ES6Spread              , "Enable ES6 Spread support"                                , DEFAULT_CONFIG_ES6Spread)
 FLAGPR           (Boolean, ES6, ES6String              , "Enable ES6 String extensions"                             , DEFAULT_CONFIG_ES6String)
 FLAGPR           (Boolean, ES6, ES6StringPrototypeFixes, "Enable ES6 String.prototype fixes"                        , DEFAULT_CONFIG_ES6StringPrototypeFixes)
+
+#ifndef COMPILE_DISABLE_ES6PrototypeChain
+    #define COMPILE_DISABLE_ES6PrototypeChain 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES6PrototypeChain      , "Enable ES6 prototypes (Example: Date prototype is object)", DEFAULT_CONFIG_ES6PrototypeChain)
 FLAGPR           (Boolean, ES6, ES6ToPrimitive         , "Enable ES6 ToPrimitive symbol"                            , DEFAULT_CONFIG_ES6ToPrimitive)
 FLAGPR           (Boolean, ES6, ES6ToLength            , "Enable ES6 ToLength fixes"                                , DEFAULT_CONFIG_ES6ToLength)
@@ -897,10 +979,22 @@ FLAGPR           (Boolean, ES6, ES6Unicode             , "Enable ES6 Unicode 6.0
 FLAGPR           (Boolean, ES6, ES6UnicodeVerbose      , "Enable ES6 Unicode 6.0 verbose failure output"            , DEFAULT_CONFIG_ES6UnicodeVerbose)
 FLAGPR           (Boolean, ES6, ES6Unscopables         , "Enable ES6 With Statement Unscopables"                    , DEFAULT_CONFIG_ES6Unscopables)
 FLAGPR           (Boolean, ES6, ES6RegExSticky         , "Enable ES6 RegEx sticky flag"                             , DEFAULT_CONFIG_ES6RegExSticky)
+
+#ifndef COMPILE_DISABLE_ES6RegExPrototypeProperties
+    #define COMPILE_DISABLE_ES6RegExPrototypeProperties 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES6RegExPrototypeProperties, "Enable ES6 properties on the RegEx prototype"         , DEFAULT_CONFIG_ES6RegExPrototypeProperties)
+
+#ifndef COMPILE_DISABLE_ES6RegExSymbols
+    #define COMPILE_DISABLE_ES6RegExSymbols 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ES6RegExSymbols        , "Enable ES6 RegExp symbols"                                , DEFAULT_CONFIG_ES6RegExSymbols)
 FLAGPR           (Boolean, ES6, ES6HasInstance         , "Enable ES6 @@hasInstance symbol"                          , DEFAULT_CONFIG_ES6HasInstanceOf)
 FLAGPR           (Boolean, ES6, ES6Verbose             , "Enable ES6 verbose trace"                                 , DEFAULT_CONFIG_ES6Verbose)
+
+#ifndef COMPILE_DISABLE_ArrayBufferTransfer
+    #define COMPILE_DISABLE_ArrayBufferTransfer 0
+#endif
 FLAGPR_REGOVR_EXP(Boolean, ES6, ArrayBufferTransfer    , "Enable ArrayBuffer.transfer"                              , DEFAULT_CONFIG_ArrayBufferTransfer)
 // /ES6 (BLUE+1) features/flags
 

--- a/deps/chakrashim/core/lib/jsrt/Jsrt.cpp
+++ b/deps/chakrashim/core/lib/jsrt/Jsrt.cpp
@@ -83,8 +83,7 @@ STDAPI_(JsErrorCode) JsCreateRuntime(_In_ JsRuntimeAttributes attributes, _In_op
             JsRuntimeAttributeDisableEval |
             JsRuntimeAttributeDisableNativeCodeGeneration |
             JsRuntimeAttributeEnableExperimentalFeatures |
-            JsRuntimeAttributeDispatchSetExceptionsToDebugger |
-            JsRuntimeAttributeEnableSimdjsFeature
+            JsRuntimeAttributeDispatchSetExceptionsToDebugger
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
             | JsRuntimeAttributeSerializeLibraryByteCode
 #endif
@@ -98,8 +97,7 @@ STDAPI_(JsErrorCode) JsCreateRuntime(_In_ JsRuntimeAttributes attributes, _In_op
 
         AllocationPolicyManager * policyManager = HeapNew(AllocationPolicyManager, (attributes & JsRuntimeAttributeDisableBackgroundWork) == 0);
         bool enableExperimentalFeatures = (attributes & JsRuntimeAttributeEnableExperimentalFeatures) != 0;
-        bool enableSimdjsFeature = (attributes & JsRuntimeAttributeEnableSimdjsFeature) != 0;
-        ThreadContext * threadContext = HeapNew(ThreadContext, policyManager, threadService, enableExperimentalFeatures, enableSimdjsFeature);
+        ThreadContext * threadContext = HeapNew(ThreadContext, policyManager, threadService, enableExperimentalFeatures);
 
         if (((attributes & JsRuntimeAttributeDisableBackgroundWork) != 0)
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS

--- a/deps/chakrashim/core/lib/jsrt/chakracommon.h
+++ b/deps/chakrashim/core/lib/jsrt/chakracommon.h
@@ -313,13 +313,7 @@
         ///     Calling <c>JsSetException</c> will also dispatch the exception to the script debugger
         ///     (if any) giving the debugger a chance to break on the exception.
         /// </summary>
-        JsRuntimeAttributeDispatchSetExceptionsToDebugger = 0x00000040,
-        /// <summary>
-        ///     Runtime will enable Simdjs experimental feature. Valid only if used with
-        ///     JsRuntimeAttributeEnableExperimentalFeatures
-        /// </summary>
-        JsRuntimeAttributeEnableSimdjsFeature = 0x00000080
-
+        JsRuntimeAttributeDispatchSetExceptionsToDebugger = 0x00000040
     } JsRuntimeAttributes;
 
     /// <summary>

--- a/deps/chakrashim/src/jsrtisolateshim.cc
+++ b/deps/chakrashim/src/jsrtisolateshim.cc
@@ -58,7 +58,7 @@ IsolateShim::~IsolateShim() {
   }
 }
 
-/* static */ v8::Isolate * IsolateShim::New(bool enableSimd) {
+/* static */ v8::Isolate * IsolateShim::New() {
   // CHAKRA-TODO: Disable multiple isolate for now until it is fully implemented
   if (s_isolateList != nullptr) {
     CHAKRA_UNIMPLEMENTED_("multiple isolate");
@@ -71,8 +71,6 @@ IsolateShim::~IsolateShim() {
     JsCreateRuntime(static_cast<JsRuntimeAttributes>(
       JsRuntimeAttributeAllowScriptInterrupt |
       JsRuntimeAttributeEnableExperimentalFeatures |
-      (enableSimd ? JsRuntimeAttributeEnableSimdjsFeature :
-       JsRuntimeAttributeNone) |
       (disableIdleGc ? JsRuntimeAttributeNone :
        JsRuntimeAttributeEnableIdleProcessing)), nullptr, &runtime);
   if (error != JsNoError) {

--- a/deps/chakrashim/src/jsrtisolateshim.h
+++ b/deps/chakrashim/src/jsrtisolateshim.h
@@ -52,7 +52,7 @@ class IsolateShim {
   bool Dispose();
   bool IsDisposing();
 
-  static v8::Isolate * New(bool enableSimd = false);
+  static v8::Isolate * New();
   static v8::Isolate * GetCurrentAsIsolate();
   static IsolateShim * GetCurrent();
   static IsolateShim * FromIsolate(v8::Isolate * isolate);

--- a/deps/chakrashim/src/v8isolate.cc
+++ b/deps/chakrashim/src/v8isolate.cc
@@ -26,10 +26,9 @@ namespace v8 {
 
 HeapProfiler dummyHeapProfiler;
 CpuProfiler dummyCpuProfiler;
-extern bool g_enableSimdjs;
 
 Isolate* Isolate::New(const CreateParams& params) {
-  Isolate* iso = jsrt::IsolateShim::New(g_enableSimdjs);
+  Isolate* iso = jsrt::IsolateShim::New();
   if (params.array_buffer_allocator) {
     V8::SetArrayBufferAllocator(params.array_buffer_allocator);
   }

--- a/deps/chakrashim/src/v8v8.cc
+++ b/deps/chakrashim/src/v8v8.cc
@@ -29,7 +29,6 @@ namespace v8 {
 bool g_disposed = false;
 bool g_exposeGC = false;
 bool g_useStrict = false;
-bool g_enableSimdjs = false;
 bool g_disableIdleGc = false;
 ArrayBuffer::Allocator* g_arrayBufferAllocator = nullptr;
 
@@ -99,11 +98,6 @@ void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
       }
     } else if (equals("--use-strict", arg) || equals("--use_strict", arg)) {
       g_useStrict = true;
-      if (remove_flags) {
-        argv[i] = nullptr;
-      }
-    } else if (equals("--harmony-simd", arg) || equals("--harmony_simd", arg)) {
-      g_enableSimdjs = true;
       if (remove_flags) {
         argv[i] = nullptr;
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

deps chakrashim
##### Description of change

<!-- provide a description of the change below this comment -->

Pull change from Microsoft/ChakraCore@62fe85a to enable/disable ES6 experimental features through preprocessor directive. 
Revert https://github.com/nodejs/node-chakracore/commit/8f005344435f6a5958c2ab668926f6eedcd394f6 and https://github.com/nodejs/node-chakracore/commit/5556a39abedc53316798c0ef76ef3b9b5b0819eb which added new JsRuntimeAttributeEnableSimdjsFeature.
