### PR TITLE
osx: new platform for node-chakracore

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -389,7 +389,6 @@
           'GCC_DYNAMIC_NO_PIC': 'NO',               # No -mdynamic-no-pic
                                                     # (Equivalent to -fPIC)
           'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
-          'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
@@ -421,6 +420,15 @@
           }],
           ['target_arch=="x64"', {
             'xcode_settings': {'ARCHS': ['x86_64']},
+          }],
+          ['node_engine=="chakracore"', {
+            'xcode_settings': {
+              'GCC_ENABLE_CPP_RTTI': 'YES',     # tr1 shared_ptr uses typeid
+            }
+          }, {
+            'xcode_settings': {
+              'GCC_ENABLE_CPP_RTTI': 'NO',      # -fno-rtti
+            }
           }],
           ['clang==1', {
             'xcode_settings': {

--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -55,7 +55,21 @@
 #define USE_EDGEMODE_JSRT     // Only works with edge JSRT
 #endif
 
+#if !defined(OSX_SDK_TR1) && defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < MAC_OS_X_VERSION_10_9
+#define OSX_SDK_TR1
+#endif
+#endif
+
+#ifdef OSX_SDK_TR1
+#include <tr1/memory>
+#define STD_SHARED_PTR std::tr1::shared_ptr
+#else
 #include <memory>
+#define STD_SHARED_PTR std::shared_ptr
+#endif
+
 #include "ChakraCore.h"
 #include "v8-version.h"
 #include "v8config.h"
@@ -448,7 +462,7 @@ struct WeakReferenceCallbackWrapper {
 };
 #ifdef _WIN32
 // xplat-todo: Is this still needed? Fail to compile xplat.
-template class V8_EXPORT std::shared_ptr<WeakReferenceCallbackWrapper>;
+template class V8_EXPORT STD_SHARED_PTR<WeakReferenceCallbackWrapper>;
 #endif
 
 // A helper method for setting an object with a WeakReferenceCallback. The
@@ -457,12 +471,12 @@ V8_EXPORT void SetObjectWeakReferenceCallback(
   JsValueRef object,
   WeakCallbackInfo<void>::Callback callback,
   void* parameters,
-  std::shared_ptr<WeakReferenceCallbackWrapper>* weakWrapper);
+  STD_SHARED_PTR<WeakReferenceCallbackWrapper>* weakWrapper);
 V8_EXPORT void SetObjectWeakReferenceCallback(
   JsValueRef object,
   WeakCallbackData<Value, void>::Callback callback,
   void* parameters,
-  std::shared_ptr<WeakReferenceCallbackWrapper>* weakWrapper);
+  STD_SHARED_PTR<WeakReferenceCallbackWrapper>* weakWrapper);
 // A helper method for turning off the WeakReferenceCallback that was set using
 // the previous method
 V8_EXPORT void ClearObjectWeakReferenceCallback(JsValueRef object, bool revive);
@@ -539,7 +553,7 @@ class PersistentBase {
   void SetWeakCommon(P* parameter, Callback callback);
 
   T* val_;
-  std::shared_ptr<chakrashim::WeakReferenceCallbackWrapper> _weakWrapper;
+  STD_SHARED_PTR<chakrashim::WeakReferenceCallbackWrapper> _weakWrapper;
 };
 
 

--- a/deps/chakrashim/src/jsrtisolateshim.h
+++ b/deps/chakrashim/src/jsrtisolateshim.h
@@ -19,8 +19,20 @@
 // IN THE SOFTWARE.
 
 #include "uv.h"
-#include <unordered_map>
 #include <vector>
+
+#if !defined(OSX_SDK_TR1) && defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < MAC_OS_X_VERSION_10_9
+#define OSX_SDK_TR1
+#endif
+#endif
+
+#ifdef OSX_SDK_TR1
+#include <tr1/unordered_map>
+#else
+#include <unordered_map>
+#endif
 
 namespace v8 {
 

--- a/deps/chakrashim/src/v8object.cc
+++ b/deps/chakrashim/src/v8object.cc
@@ -24,7 +24,6 @@
 
 namespace v8 {
 
-using std::unique_ptr;
 using namespace jsrt;
 
 enum AccessorType {

--- a/deps/chakrashim/src/v8persistent.cc
+++ b/deps/chakrashim/src/v8persistent.cc
@@ -61,14 +61,14 @@ template <class Callback, class Func>
 void SetObjectWeakReferenceCallbackCommon(
     JsValueRef object,
     Callback callback,
-    std::shared_ptr<WeakReferenceCallbackWrapper>* weakWrapper,
+    STD_SHARED_PTR<WeakReferenceCallbackWrapper>* weakWrapper,
     const Func& initWrapper) {
   if (callback == nullptr || object == JS_INVALID_REFERENCE) {
     return;
   }
 
   if (!*weakWrapper) {
-    *weakWrapper = std::make_shared<WeakReferenceCallbackWrapper>();
+    (*weakWrapper).reset(new WeakReferenceCallbackWrapper());
   }
 
   WeakReferenceCallbackWrapper *callbackWrapper = (*weakWrapper).get();
@@ -83,7 +83,7 @@ void SetObjectWeakReferenceCallback(
     JsValueRef object,
     WeakCallbackInfo<void>::Callback callback,
     void* parameters,
-    std::shared_ptr<WeakReferenceCallbackWrapper>* weakWrapper) {
+    STD_SHARED_PTR<WeakReferenceCallbackWrapper>* weakWrapper) {
   SetObjectWeakReferenceCallbackCommon(
     object, callback, weakWrapper,
     [=](WeakReferenceCallbackWrapper *callbackWrapper) {
@@ -97,7 +97,7 @@ void SetObjectWeakReferenceCallback(
     JsValueRef object,
     WeakCallbackData<Value, void>::Callback callback,
     void* parameters,
-    std::shared_ptr<WeakReferenceCallbackWrapper>* weakWrapper) {
+    STD_SHARED_PTR<WeakReferenceCallbackWrapper>* weakWrapper) {
   SetObjectWeakReferenceCallbackCommon(
     object, callback, weakWrapper,
     [=](WeakReferenceCallbackWrapper *callbackWrapper) {

--- a/deps/chakrashim/src/v8string.cc
+++ b/deps/chakrashim/src/v8string.cc
@@ -22,8 +22,6 @@
 
 namespace v8 {
 
-using std::unique_ptr;
-
 String::Utf8Value::Utf8Value(Handle<v8::Value> obj)
     : _str(nullptr), _length(0) {
   Handle<String> str = obj->ToString();

--- a/deps/chakrashim/src/v8value.cc
+++ b/deps/chakrashim/src/v8value.cc
@@ -22,6 +22,16 @@
 #include <limits.h>
 #include <math.h>
 
+#ifdef __APPLE__
+inline int isnan(double x) { 
+  return std::isnan(x);
+}
+
+int isfinite(double x) { 
+  return std::isfinite(x);
+}
+#endif
+
 namespace v8 {
 
 using jsrt::ContextShim;


### PR DESCRIPTION
This PR;
- node-chakracore runs on OSX
- similar test fail rate comparing to linux build
- considered std::tr1 for osx < 10.9
- added a todo note for icu-lib location customization (node has a flag for that already though)
