### PR TITLE
chakrashim: Fix xplat build inconsistencies

### DIFF
--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -11,6 +11,7 @@
     'linker_end_group%': '',
     'chakra_libs_absolute%': '',
     'icu_lib_path%': '',
+    'chakra_build_flags': '',
 
     # xplat (non-win32) only
     'chakra_config': 'Release',     # Debug, Release
@@ -28,12 +29,15 @@
         'icu_include_path': '/usr/local/opt/icu4c/include'
       }],
 
+      # xplat-todo: we need to build CC release/debug without breaking the previous cache
+      # node compiles both release and debug on `debug` mode.
+      # ChakraCore ends-up overwriting the previous build cache
       # xplat (non-win32) only
-      ['chakra_config=="Debug"', {
-        'chakra_build_flags': [ '-d' ],
-      }, {
-        'chakra_build_flags': [],
-      }],
+      # ['chakra_config=="Debug"', {
+      #   'chakra_build_flags': [ '-d' ],
+      # }, {
+      #   'chakra_build_flags': [],
+      # }],
     ],
   },
 
@@ -129,7 +133,6 @@
                 '<(chakra_dir)/build.sh',
                 '--without=Simdjs',
                 '--static',
-                '-j',
                 '<@(chakra_build_flags)',
                 '<@(icu_args)'
               ],


### PR DESCRIPTION
`-j` option fails randomly.
node `debug` option builds in both release and debug modes.
CC needs a separate cache for debug/release

May possibly fix #121 
