### PR TITLE
chakrashim: Remove shared_ptr usage

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -389,6 +389,7 @@
           'GCC_DYNAMIC_NO_PIC': 'NO',               # No -mdynamic-no-pic
                                                     # (Equivalent to -fPIC)
           'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
+          'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
@@ -420,15 +421,6 @@
           }],
           ['target_arch=="x64"', {
             'xcode_settings': {'ARCHS': ['x86_64']},
-          }],
-          ['node_engine=="chakracore"', {
-            'xcode_settings': {
-              'GCC_ENABLE_CPP_RTTI': 'YES',     # tr1 shared_ptr uses typeid
-            }
-          }, {
-            'xcode_settings': {
-              'GCC_ENABLE_CPP_RTTI': 'NO',      # -fno-rtti
-            }
           }],
           ['clang==1', {
             'xcode_settings': {


### PR DESCRIPTION
- Removes shared_ptr usage from chakrashim
- Updates common.gypi to its previous state
- Chakrashim no longer needs RTTI is enabled on OSX
