### PR TITLE
ChakraCore CI support

### DIFF
--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -1,0 +1,51 @@
+prefix addons
+
+# To mark a test as flaky, list the test name in the appropriate section
+# below, without ".js", followed by ": PASS,FLAKY". Example:
+# sample-test                        : PASS,FLAKY
+
+[true] # This section applies to all platforms
+
+[$system==win32]
+
+[$system==linux]
+
+[$system==macos]
+
+[$system==solaris]
+
+[$system==freebsd]
+
+[$system==aix]
+
+[$jsEngine==chakracore]
+01_callbacks/test : SKIP
+02_object_factory/test : SKIP
+03_function_factory/test : SKIP
+04_wrapping_c_objects/test : SKIP
+05_factory_of_wrapped_objects/test : SKIP
+06_passing_wrapped_objects_around/test : SKIP
+07_atexit_hooks/test : SKIP
+async-hello-world/test : SKIP
+at-exit/test : SKIP
+buffer-free-callback/test : SKIP
+heap-profiler/test : SKIP
+hello-world-function-export/test : SKIP
+hello-world/test : SKIP
+load-long-path/test : SKIP
+make-callback-recurse/test : SKIP
+make-callback/test : SKIP
+null-buffer-neuter/test : SKIP
+openssl-binding/test : SKIP
+parse-encoding/test : SKIP
+repl-domain-abort/test : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-at-max : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64 : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8 : SKIP
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2 : SKIP
+symlinked-module/test : SKIP
+zlib-binding/test : SKIP

--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -18,3 +18,6 @@ test-stdout-buffer-flush-on-exit: SKIP
 [$system==freebsd]
 
 [$system==aix]
+
+[$jsEngine==chakracore]
+test-vm-function-redefinition : SKIP

--- a/test/message/message.status
+++ b/test/message/message.status
@@ -16,3 +16,4 @@ prefix message
 
 [$system==freebsd]
 
+[$jsEngine==chakracore]

--- a/test/message/testcfg.py
+++ b/test/message/testcfg.py
@@ -111,7 +111,6 @@ class MessageTestConfiguration(test.TestConfiguration):
 
   def __init__(self, context, root):
     super(MessageTestConfiguration, self).__init__(context, root)
-    self.engine = context.engine
 
   def Ls(self, path):
     if isdir(path):
@@ -119,14 +118,14 @@ class MessageTestConfiguration(test.TestConfiguration):
     else:
         return []
 
-  def ListTests(self, current_path, path, arch, mode):
+  def ListTests(self, current_path, path, arch, mode, jsEngine):
     all_tests = [current_path + [t] for t in self.Ls(self.root)]
     result = []
     for test in all_tests:
       if self.Contains(path, test):
         file_prefix = join(self.root, reduce(join, test[1:], ""))
         file_path = file_prefix + ".js"
-        engine_output_path = file_prefix + (".%s.out" % self.engine)
+        engine_output_path = file_prefix + (".%s.out" % jsEngine)
         output_path = file_prefix + ".out"
         if exists(engine_output_path):
           output_path = engine_output_path

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -36,3 +36,34 @@ test-debug-signal-cluster                : PASS, FLAKY
 
 #covered by https://github.com/nodejs/node/issues/8271
 test-child-process-fork-dgram            : PASS, FLAKY
+
+[$jsEngine==chakracore]
+test-buffer-includes : SKIP
+test-buffer-indexof : SKIP
+test-buffer-slow : SKIP
+test-crypto-dh : SKIP
+test-force-repl : SKIP
+test-force-repl-with-eval : SKIP
+test-fs-stat : SKIP
+test-http-same-map : SKIP
+test-intl : SKIP
+test-promises-unhandled-rejections : SKIP
+test-promises-warning-on-unhandled-rejection : SKIP
+test-repl : SKIP
+test-repl-mode : SKIP
+test-repl-tab-complete : SKIP
+test-repl-timeout-throw : SKIP
+test-string-decoder : SKIP
+test-timers-blocking-callback : SKIP
+test-timers-same-timeout-wrong-list-deleted : SKIP
+test-util-inspect-proxy : SKIP
+test-util-inspect-simd : SKIP
+test-vm-cached-data : SKIP
+test-vm-context : SKIP
+test-vm-create-and-run-in-context : SKIP
+test-vm-global-identity : SKIP
+test-vm-low-stack-space : SKIP
+test-vm-preserves-property : SKIP
+test-vm-proxies : SKIP
+test-vm-strict-mode : SKIP
+test-vm-timeout : SKIP

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -38,9 +38,6 @@ test-debug-signal-cluster                : PASS, FLAKY
 test-child-process-fork-dgram            : PASS, FLAKY
 
 [$jsEngine==chakracore]
-test-buffer-includes : SKIP
-test-buffer-indexof : SKIP
-test-buffer-slow : SKIP
 test-crypto-dh : SKIP
 test-force-repl : SKIP
 test-force-repl-with-eval : SKIP
@@ -67,3 +64,8 @@ test-vm-preserves-property : SKIP
 test-vm-proxies : SKIP
 test-vm-strict-mode : SKIP
 test-vm-timeout : SKIP
+
+[$jsEngine==chakracore && $arch==x64]
+test-buffer-includes : SKIP
+test-buffer-indexof : SKIP
+test-buffer-slow : SKIP

--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -128,7 +128,7 @@ class TTYTestConfiguration(test.TestConfiguration):
     else:
         return []
 
-  def ListTests(self, current_path, path, arch, mode):
+  def ListTests(self, current_path, path, arch, mode, jsEngine):
     all_tests = [current_path + [t] for t in self.Ls(self.root)]
     result = []
     # Skip these tests on Windows, as pseudo terminals are not available

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -22,3 +22,8 @@ prefix sequential
 # regressions until this work is complete
 [$system==aix]
 test-fs-watch               : FAIL,PASS
+
+[$jsEngine==chakracore]
+test-http-regr-gh-2928 : SKIP
+test-net-GH-5504 : SKIP
+test-vm-timeout-rethrow : SKIP

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -94,7 +94,7 @@ class SimpleTestConfiguration(test.TestConfiguration):
       return name.startswith('test-') and name.endswith('.js')
     return [f[:-3] for f in os.listdir(path) if SelectTest(f)]
 
-  def ListTests(self, current_path, path, arch, mode):
+  def ListTests(self, current_path, path, arch, mode, jsEngine):
     all_tests = [current_path + [t] for t in self.Ls(join(self.root))]
     result = []
     for test in all_tests:
@@ -117,9 +117,9 @@ class ParallelTestConfiguration(SimpleTestConfiguration):
     super(ParallelTestConfiguration, self).__init__(context, root, section,
                                                     additional)
 
-  def ListTests(self, current_path, path, arch, mode):
+  def ListTests(self, current_path, path, arch, mode, jsEngine):
     result = super(ParallelTestConfiguration, self).ListTests(
-         current_path, path, arch, mode)
+         current_path, path, arch, mode, jsEngine)
     for test in result:
       test.parallel = True
     return result
@@ -140,7 +140,7 @@ class AddonTestConfiguration(SimpleTestConfiguration):
             result.append([subpath, f[:-3]])
     return result
 
-  def ListTests(self, current_path, path, arch, mode):
+  def ListTests(self, current_path, path, arch, mode, jsEngine):
     all_tests = [current_path + t for t in self.Ls(join(self.root))]
     result = []
     for test in all_tests:

--- a/test/timers/testcfg.py
+++ b/test/timers/testcfg.py
@@ -76,7 +76,7 @@ class TimersTestConfiguration(test.TestConfiguration):
       return name.startswith('test-') and name.endswith('.js')
     return [f[:-3] for f in os.listdir(path) if SelectTest(f)]
 
-  def ListTests(self, current_path, path, arch, mode):
+  def ListTests(self, current_path, path, arch, mode, jsEngine):
     all_tests = [current_path + [t] for t in self.Ls(join(self.root))]
     result = []
     for test in all_tests:

--- a/tools/test.py
+++ b/tools/test.py
@@ -1564,10 +1564,17 @@ def Main():
           print "Can't determine the arch of: '%s'" % vm
           print archEngineContext.stderr.rstrip()
           continue
+        jsEngineContext = Execute([vm, "-p", "process.jsEngine"], context)
+        jsEngine = jsEngineContext.stdout.rstrip()
+        if jsEngineContext.exit_code is not 0 or jsEngine == "undefined":
+          print "Can't determine the jsEngine of: '%s'" % vm
+          print jsEngineContext.stderr.rstrip()
+          continue
         env = {
           'mode': mode,
           'system': utils.GuessOS(),
           'arch': vmArch,
+          'jsengine': jsEngine, # variable names are lowercased
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list

--- a/tools/test.py
+++ b/tools/test.py
@@ -1556,13 +1556,13 @@ def Main():
           continue
         archEngineContext = Execute([vm, "-p", "process.arch"], context)
         vmArch = archEngineContext.stdout.rstrip()
-        if archEngineContext.exit_code is not 0 or vmArch == "undefined":
+        if archEngineContext.exit_code != 0 or vmArch == "undefined":
           print "Can't determine the arch of: '%s'" % vm
           print archEngineContext.stderr.rstrip()
           continue
         jsEngineContext = Execute([vm, "-p", "process.jsEngine"], context)
         jsEngine = jsEngineContext.stdout.rstrip()
-        if jsEngineContext.exit_code is not 0 or jsEngine == "undefined":
+        if jsEngineContext.exit_code != 0 or jsEngine == "undefined":
           print "Can't determine the jsEngine of: '%s'" % vm
           print jsEngineContext.stderr.rstrip()
           continue

--- a/tools/test.py
+++ b/tools/test.py
@@ -1567,10 +1567,12 @@ def Main():
           print jsEngineContext.stderr.rstrip()
           continue
         env = {
+          # variable names are lowercased when reading the status files
+          # any uppercase character here will prevent the names from matching
           'mode': mode,
           'system': utils.GuessOS(),
           'arch': vmArch,
-          'jsengine': jsEngine, # variable names are lowercased
+          'jsengine': jsEngine,
         }
         test_list = root.ListTests([], path, context, arch, mode, jsEngine)
         unclassified_tests += test_list

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -358,7 +358,6 @@ goto run-tests
 if "%test_args%"=="" goto jslint
 if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
-set test_args=--engine %engine% %test_args%
 echo running 'cctest'
 "%config%\cctest"
 echo running 'python tools\test.py %test_args%'


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

Test
##### Description of change

This PR adds support to specify tests as flaky/skip/... independently by JavaScript engine.

The first two commits add the logic to detect the `jsEngine` in `test.py` when running the tests, and use that variable when reading the status files. The `--engine` argument of `test.py` is no longer necessary, so this reverts parts of https://github.com/nodejs/node-chakracore/commit/42bc2848a89a9f9ee145f9fdfe057465c410b2d9 and https://github.com/nodejs/node-chakracore/commit/50398dab52ad8c03745f0869cd632ab0f8c3d09e where it was added. The `jsEngine` variable is now passed to the test suites in a way that follows the change introduced in https://github.com/nodejs/node-chakracore/commit/edaf7af30bddef699ea68726fedd7a28d1dc999a .

The last commit adds an initial list of tests that are failing with ChakraCore on CI, gathered from several CI runs.

@nodejs/node-chakracore the CI job to test node-chakracore is now ready to be used: https://ci.nodejs.org/view/All/job/chakracore-test-windows/

CI for this PR: https://ci.nodejs.org/view/All/job/chakracore-test-windows/20/

CI fails because Visual C++ Build Tools are not yet supported, this is being tracked in https://github.com/nodejs/node-chakracore/issues/24 . All VS2015 builds are green.
