### PR TITLE
build: add ChakraCore SDK to packages

### DIFF
--- a/deps/chakrashim/npm
+++ b/deps/chakrashim/npm
@@ -1,0 +1,4 @@
+#!/bin/bash
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+export NPM_CONFIG_NODEDIR="$DIR"
+$DIR/lib/node_modules/npm/bin/npm-cli.js "$@"

--- a/tools/install.py
+++ b/tools/install.py
@@ -89,14 +89,8 @@ def npm_files(action):
     paths = [os.path.join(dirname, basename) for basename in basenames]
     action(paths, target_path + dirname[9:] + '/')
 
-  # create/remove symlink
-  link_path = abspath(install_path, 'bin/npm')
-  if action == uninstall:
-    action([link_path], 'bin/npm')
-  elif action == install:
-    try_symlink('../lib/node_modules/npm/bin/npm-cli.js', link_path)
-  else:
-    assert(0) # unhandled action type
+  # create/remove npm invoke script
+  action(['deps/chakrashim/npm'], 'bin/npm')
 
 def subdir_files(path, dest, action):
   ret = {}

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -241,6 +241,21 @@ if not defined noperfctr (
     if errorlevel 1 echo Cannot copy node_perfctr_provider.man && goto package_error
 )
 
+:: ChakraCore SDK for native modules
+robocopy ..\ node-v%FULLVERSION%-win-%target_arch%\sdk\ *.h *.inc common.gypi /XD debug release build icu core test genfiles /S > nul
+if errorlevel 8 echo Cannot copy SDK contents && goto package_error
+mkdir node-v%FULLVERSION%-win-%target_arch%\sdk\%config% > nul 2> nul
+copy /Y node.lib node-v%FULLVERSION%-win-%target_arch%\sdk\%config%\ > nul
+if errorlevel 1 echo Cannot copy node.lib && goto package_error
+copy /Y chakracore.lib node-v%FULLVERSION%-win-%target_arch%\sdk\%config%\ > nul
+if errorlevel 1 echo Cannot copy chakracore.lib && goto package_error
+set "pkgnpmsh=node-v%FULLVERSION%-win-%target_arch%/npm"
+node.exe -e "var data=fs.readFileSync('%pkgnpmsh%', 'utf8').split('\n');data.splice(-2, 0, 'export NPM_CONFIG_NODEDIR=\"$basedir/sdk\"');fs.writeFileSync('%pkgnpmsh%', data.join('\n'))"
+if errorlevel 1 echo Cannot change %pkgnpmsh% && goto package_error
+set "pkgnpmcmd=node-v%FULLVERSION%-win-%target_arch%/npm.cmd"
+node.exe -e "var data=fs.readFileSync('%pkgnpmcmd%', 'utf8').split('\n');data.splice(-2, 0, 'SET \"NPM_CONFIG_NODEDIR=%%~dp0\\sdk\"');fs.writeFileSync('%pkgnpmcmd%', data.join('\n'))"
+if errorlevel 1 echo Cannot change %pkgnpmcmd% && goto package_error
+
 echo Creating node-v%FULLVERSION%-win-%target_arch%.7z
 del node-v%FULLVERSION%-win-%target_arch%.7z > nul 2> nul
 7z a -r -mx9 -t7z node-v%FULLVERSION%-win-%target_arch%.7z node-v%FULLVERSION%-win-%target_arch% > nul


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Build

##### Description of change

This change enables compilation of native modules with Node-ChakraCore when using the `zip/7z` (Windows) or `tar.gz/tar.xz` (Unix) packages. This is achieved by including the headers in the Windows package (Unix already did) and always invoking npm with the environment variable `npm_config_nodedir` set.

This is only necessary until full integration with node-gyp is achieved, then this commit can be easily reverted.

Test build: https://nodejs.org/download/test/v7.0.0-test2016112325b107538b/

cc @nodejs/node-chakracore 
