### PR TITLE
xplat: fixes for native modules

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -47,9 +47,11 @@
       ['GENERATOR == "ninja" or OS== "mac"', {
         'OBJ_DIR': '<(PRODUCT_DIR)/obj',
         'V8_BASE': '<(PRODUCT_DIR)/libv8_base.a',
+        'CHAKRASHIM_BASE': '<(PRODUCT_DIR)/libchakrashim.a',
       }, {
         'OBJ_DIR': '<(PRODUCT_DIR)/obj.target',
         'V8_BASE': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
+        'CHAKRASHIM_BASE': '<(PRODUCT_DIR)/obj.target/deps/chakrashim/libchakrashim.a',
       }],
       ['openssl_fips != ""', {
         'OPENSSL_PRODUCT': 'libcrypto.a',

--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -2424,6 +2424,13 @@ class V8_EXPORT Context {
     ExtensionConfiguration* extensions = NULL,
     Handle<ObjectTemplate> global_template = Handle<ObjectTemplate>(),
     Handle<Value> global_object = Handle<Value>());
+  static Local<Context> New(
+    Isolate* isolate,
+    ExtensionConfiguration* extensions,
+    Handle<ObjectTemplate> global_template = Handle<ObjectTemplate>(),
+    Handle<Value> global_object = Handle<Value>()) {
+    return New(isolate, false, extensions, global_template, global_object);
+  }
   static Local<Context> GetCurrent();
 
   Isolate* GetIsolate();

--- a/node.gyp
+++ b/node.gyp
@@ -571,10 +571,16 @@
           'conditions': [
             [ 'node_engine=="v8"', {
               'ldflags': [
-                       '-Wl,--whole-archive <(V8_BASE)',
+                '-Wl,--whole-archive <(V8_BASE)',
                 '-Wl,--no-whole-archive',
               ],
-        }],
+            }],
+            ['node_engine=="chakracore"', {
+              'ldflags': [
+                '-Wl,--whole-archive <(CHAKRASHIM_BASE)',
+                '-Wl,--no-whole-archive',
+              ],
+            }],
           ],
         }],
         [ 'OS=="sunos"', {

--- a/tools/install.py
+++ b/tools/install.py
@@ -151,7 +151,13 @@ def headers(action):
   if sys.platform.startswith('aix'):
     action(['out/Release/node.exp'], 'include/node/')
 
-  subdir_files('deps/v8/include', 'include/node/', action)
+  if 'v8' == variables.get('node_engine'):
+    subdir_files('deps/v8/include', 'include/node/', action)
+  elif 'chakracore' == variables.get('node_engine'):
+    subdir_files('deps/chakrashim/include', 'include/node/', action)
+    subdir_files('deps/chakrashim/src', 'include/node/', action)
+  else:
+    assert(0) # unhandled engine
 
   if 'false' == variables.get('node_shared_cares'):
     subdir_files('deps/cares/include', 'include/node/', action)

--- a/tools/install.py
+++ b/tools/install.py
@@ -157,7 +157,7 @@ def headers(action):
     subdir_files('deps/chakrashim/include', 'include/node/', action)
     subdir_files('deps/chakrashim/src', 'include/node/', action)
   else:
-    assert(0) # unhandled engine
+    raise RuntimeError('Unknown engine: %s\n' % variables.get('node_engine'))
 
   if 'false' == variables.get('node_shared_cares'):
     subdir_files('deps/cares/include', 'include/node/', action)


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Build and ChakraShim.

##### Description of change

This PR fixes build and using native modules in Windows, Linux and Mac OS X. It consists of 3 commits:
- https://github.com/nodejs/node-chakracore/commit/702f4f82970274c1ab4ca7fa46ef61c1a10dbf3e : Include all of `chakrashim.lib` in the executable, so all of it can be used by native modules on Unix platforms. This is similar to what is done for V8. This effectively adds the following symbols to the executable:
```
v8::NumberObject::New(v8::Isolate*, double)
v8::NumberObject::Cast(v8::Value*)
v8::StringObject::New(v8::Local<v8::String>)
v8::StringObject::Cast(v8::Value*)
v8::BooleanObject::New(bool)
v8::BooleanObject::New(v8::Isolate*, bool)
v8::BooleanObject::Cast(v8::Value*)
v8::Date::New(v8::Local<v8::Context>, double)
v8::Date::New(v8::Isolate*, double)
v8::Date::Cast(v8::Value*)
```
- https://github.com/nodejs/node-chakracore/commit/4932d7046ee6a011a6c8400784cce51c0a7a3ecd : Include ChakraShim headers instead of V8 in `install.py`, used to build the binary package we currently provide in nightlies.
- https://github.com/nodejs/node-chakracore/commit/bd15adad5c2a0b924e46055468b0ea971d6daf30 : Work around a [V8 definition change](https://github.com/nodejs/node-chakracore/blob/bd30117e313a85ec9f18f025a309a5c7df7bd1a8/deps/chakrashim/include/v8.h#L2423) introduced for TTD in https://github.com/nodejs/node-chakracore/pull/143.

Test build: https://nodejs.org/download/test/v7.0.0-test20161202bd15adad5c/

cc @nodejs/node-chakracore 
