### PR TITLE
TTD -- Fix interaction with debugger in deps core.

### DIFF
--- a/deps/chakrashim/core/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/deps/chakrashim/core/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -1832,28 +1832,17 @@ namespace Js
 
 #if ENABLE_TTD
             bool suppressGetterForTTDebug = requestContext->GetThreadContext()->IsRuntimeInTTDMode() && requestContext->GetThreadContext()->TTDLog->ShouldDoGetterInvocationSupression();
+            TTD::TTModeStackAutoPopper suppressModeAutoPopper(requestContext->GetThreadContext()->TTDLog);
             if(suppressGetterForTTDebug)
             {
-                requestContext->GetThreadContext()->TTDLog->PushMode(TTD::TTDMode::DebuggerSuppressGetter);
+                suppressModeAutoPopper.PushModeAndSetToAutoPop(TTD::TTDMode::DebuggerSuppressGetter);
             }
+#endif
 
-            BOOL success = Js::JavascriptOperators::GetProperty(obj, propId, &objValue, requestContext);
-
-            if(suppressGetterForTTDebug)
-            {
-                requestContext->GetThreadContext()->TTDLog->PopMode(TTD::TTDMode::DebuggerSuppressGetter);
-            }
-
-            if(success)
-            {
-                return objValue;
-            }
-#else
             if (Js::JavascriptOperators::GetProperty(obj, propId, &objValue, requestContext))
             {
                 return objValue;
             }
-#endif
         }
 
         return nullptr;
@@ -2197,9 +2186,10 @@ namespace Js
 
 #if ENABLE_TTD
         bool suppressGetterForTTDebug = scriptContext->GetThreadContext()->IsRuntimeInTTDMode() && scriptContext->GetThreadContext()->TTDLog->ShouldDoGetterInvocationSupression();
+        TTD::TTModeStackAutoPopper suppressModeAutoPopper(scriptContext->GetThreadContext()->TTDLog);
         if(suppressGetterForTTDebug)
         {
-            instance->GetScriptContext()->GetThreadContext()->TTDLog->PushMode(TTD::TTDMode::DebuggerSuppressGetter);
+            suppressModeAutoPopper.PushModeAndSetToAutoPop(TTD::TTDMode::DebuggerSuppressGetter);
         }
 #endif
 
@@ -2216,13 +2206,6 @@ namespace Js
         {
             retValue = Js::JavascriptOperators::GetProperty(originalInstance, instance, propertyId, value, scriptContext);
         }
-
-#if ENABLE_TTD
-        if(suppressGetterForTTDebug)
-        {
-            instance->GetScriptContext()->GetThreadContext()->TTDLog->PopMode(TTD::TTDMode::DebuggerSuppressGetter);
-        }
-#endif
 
         return retValue;
     }

--- a/deps/chakrashim/core/lib/Runtime/Debug/TTEventLog.h
+++ b/deps/chakrashim/core/lib/Runtime/Debug/TTEventLog.h
@@ -748,6 +748,35 @@ namespace TTD
             this->m_log = nullptr; //normal pop (no exception) just clear so destructor nops
         }
     };
+
+    //In cases where we may have many exits where we need to pop something we pushed earlier (i.e. exceptions)
+    class TTModeStackAutoPopper
+    {
+    private:
+        EventLog* m_log;
+        TTDMode m_popMode; //the mode to pop or invalid if we don't need to pop anything
+
+    public:
+        TTModeStackAutoPopper(EventLog* log)
+            : m_log(log), m_popMode(TTDMode::Invalid)
+        {
+            ;
+        }
+
+        void PushModeAndSetToAutoPop(TTDMode mode)
+        {
+            this->m_log->PushMode(mode);
+            this->m_popMode = mode;
+        }
+
+        ~TTModeStackAutoPopper()
+        {
+            if(this->m_popMode != TTDMode::Invalid)
+            {
+                this->m_log->PopMode(this->m_popMode);
+            }
+        }
+    };
 }
 
 #endif


### PR DESCRIPTION
Out of band patch to core module to fix bug with TTD/debugger interaction. The diag enumerator may throw an exception (and we do not pop the TTD debugger mode on this path) putting the debugger & TTD system out of sync. Adding auto destructor class to ensure pop happens on all control paths.