### PR TITLE
chakrashim: Fix SEH unwind context conditional

### DIFF
--- a/deps/chakrashim/core/pal/src/exception/seh-unwind.cpp
+++ b/deps/chakrashim/core/pal/src/exception/seh-unwind.cpp
@@ -502,7 +502,17 @@ BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 
     LibunwindCallbacksInfo.Context = context;
     LibunwindCallbacksInfo.readMemCallback = readMemCallback;
+
+#if UNWIND_CONTEXT_IS_UCONTEXT_T
     WinContextToUnwindContext(context, &unwContext);
+#else
+    st = unw_getcontext(&unwContext);
+    if (st < 0)
+    {
+        return FALSE;
+    }
+#endif
+
     addrSpace = unw_create_addr_space(&unwind_accessors, 0);
 #ifdef HAVE_LIBUNWIND_PTRACE
     libunwindUptPtr = _UPT_create(pid);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included (n/a)
- [ ] documentation is changed or added (n/a)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim

##### Description of change
<!-- Provide a description of the change below this comment. -->
I encountered a build error on Linux related to `WinContextToUnwindContext`. I found that the use of `WinContextToUnwindContext` should be conditional on the `UNWIND_CONTEXT_IS_UCONTEXT_T` preprocessor define here like it is elsewhere, enabling builds on platforms where `UNWIND_CONTEXT_IS_UCONTEXT_T` is false.

I am unfamiliar with this code, so I hope reviewers can validate. But this seems a straightforward duplication of [the pattern at lines 236-246 in the same file](https://github.com/nodejs/node-chakracore/blob/xplat/deps/chakrashim/core/pal/src/exception/seh-unwind.cpp#L239-L246).