### PR TITLE
Fix cpplint warns and add TTD performance checks.

### DIFF
--- a/deps/chakrashim/src/v8arraybuffer.cc
+++ b/deps/chakrashim/src/v8arraybuffer.cc
@@ -107,20 +107,21 @@ ArrayBuffer::Contents ArrayBuffer::GetContents() {
 }
 
 // ENABLE_TTD
-void ArrayBuffer::TTDRawBufferNotifyRegisterForModification(byte* initialModPosition) {
-    JsTTDRawBufferAsyncModificationRegister(this, initialModPosition);
+void ArrayBuffer::TTDRawBufferNotifyRegisterForModification(
+  byte* initialModPosition) {
+  JsTTDRawBufferAsyncModificationRegister(this, initialModPosition);
 }
 
 void ArrayBuffer::TTDRawBufferAsyncModifyComplete(byte* finalModPosition) {
-    JsTTDRawBufferAsyncModifyComplete(finalModPosition);
+  JsTTDRawBufferAsyncModifyComplete(finalModPosition);
 }
 void ArrayBuffer::TTDRawBufferModifyNotifySync(UINT32 index, UINT32 count) {
-    JsTTDRawBufferModifySyncIndirect(this, index, count);
+  JsTTDRawBufferModifySyncIndirect(this, index, count);
 }
 void ArrayBuffer::TTDRawBufferCopyNotify(Local<ArrayBuffer> dst,
-                                         UINT32 dstindex, Local<ArrayBuffer> src, 
+                                         UINT32 dstindex, Local<ArrayBuffer> src,
                                          UINT32 srcIndex, UINT32 count) {
-    JsTTDRawBufferCopySyncIndirect(*dst, dstindex, *src, srcIndex, count);
+  JsTTDRawBufferCopySyncIndirect(*dst, dstindex, *src, srcIndex, count);
 }
 
 ArrayBuffer* ArrayBuffer::Cast(Value* obj) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -387,7 +387,8 @@ inline v8::Local<v8::Float64Array> Environment::fs_stats_field_array() const {
   return v8::Local<v8::Float64Array>::New(isolate_, fs_stats_field_array_);
 }
 
-inline void Environment::set_fs_stats_field_array(v8::Local<v8::Float64Array> fields) {
+inline void Environment::set_fs_stats_field_array(
+    v8::Local<v8::Float64Array> fields) {
   CHECK_EQ(fs_stats_field_array_.IsEmpty(), true);  // Should be set only once.
   fs_stats_field_array_ = v8::Global<v8::Float64Array>::New(isolate_, fields);
 }

--- a/src/env.h
+++ b/src/env.h
@@ -602,7 +602,7 @@ class Environment {
 
   char* http_parser_buffer_;
 
-  //We depend on the property in fs.js to manage the lifetime appropriately
+  // We depend on the property in fs.js to manage the lifetime appropriately
   v8::Global<v8::Float64Array> fs_stats_field_array_;
 
 #define V(PropertyName, TypeName)                                             \

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -227,7 +227,8 @@ size_t Length(Local<Value> val) {
 }
 
 #if ENABLE_TTD_NODE
-void TTDAsyncModRegister(v8::Local<v8::Object> val, unsigned char* initialModPosition) {
+void TTDAsyncModRegister(v8::Local<v8::Object> val,
+                         unsigned char* initialModPosition) {
   CHECK(val->IsUint8Array());
   Local<Uint8Array> ui = val.As<Uint8Array>();
   ui->Buffer()->TTDRawBufferNotifyRegisterForModification(initialModPosition);
@@ -596,11 +597,13 @@ void Copy(const FunctionCallbackInfo<Value> &args) {
   args.GetReturnValue().Set(to_copy);
 
 #if ENABLE_TTD_NODE
-  ArrayBuffer::TTDRawBufferCopyNotify(target->Buffer(),
-                                      target_offset + target_start,
-                                      ts_obj->Buffer(),
-                                      ts_obj_offset + source_start,
-                                      to_copy);
+  if (s_doTTRecord || s_doTTReplay) {
+    ArrayBuffer::TTDRawBufferCopyNotify(target->Buffer(),
+                                        target_offset + target_start,
+                                        ts_obj->Buffer(),
+                                        ts_obj_offset + source_start,
+                                        to_copy);
+  }
 #endif
 }
 
@@ -638,7 +641,9 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
     // TODO(mrkmarron): We could improve performance since this is a constant
     // value. Fill by just logging constant (instead of copying modified range).
     //
-    ts_obj->Buffer()->TTDRawBufferModifyNotifySync(start, fill_length);
+    if (s_doTTRecord || s_doTTReplay) {
+      ts_obj->Buffer()->TTDRawBufferModifyNotifySync(start, fill_length);
+    }
 #endif
 
     return;
@@ -760,8 +765,10 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(written);
 
 #if ENABLE_TTD_NODE
-  args.This().As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
-          ts_obj_offset + offset, written);
+  if (s_doTTRecord || s_doTTReplay) {
+    args.This().As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
+      ts_obj_offset + offset, written);
+  }
 #endif
 }
 
@@ -903,8 +910,10 @@ void WriteFloatGeneric(const FunctionCallbackInfo<Value>& args) {
     Swizzle(na.bytes, sizeof(na.bytes));
   memcpy(ptr, na.bytes, memcpy_num);
 #if ENABLE_TTD_NODE
-  ts_obj->Buffer()->TTDRawBufferModifyNotifySync(ts_obj_offset + offset,
-                                                 memcpy_num);
+  if (s_doTTRecord || s_doTTReplay) {
+    ts_obj->Buffer()->TTDRawBufferModifyNotifySync(ts_obj_offset + offset,
+                                                   memcpy_num);
+  }
 #endif
 }
 
@@ -1253,8 +1262,10 @@ void Swap16(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(args[0]);
 
 #if ENABLE_TTD_NODE
-  args[0].As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
-          ts_obj_offset, ts_obj_length);
+  if (s_doTTRecord || s_doTTReplay) {
+    args[0].As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
+      ts_obj_offset, ts_obj_length);
+  }
 #endif
 }
 
@@ -1267,8 +1278,10 @@ void Swap32(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(args[0]);
 
 #if ENABLE_TTD_NODE
-  args[0].As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
-          ts_obj_offset, ts_obj_length);
+  if (s_doTTRecord || s_doTTReplay) {
+    args[0].As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
+      ts_obj_offset, ts_obj_length);
+  }
 #endif
 }
 
@@ -1281,8 +1294,10 @@ void Swap64(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(args[0]);
 
 #if ENABLE_TTD_NODE
-  args[0].As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
-          ts_obj_offset, ts_obj_length);
+  if (s_doTTRecord || s_doTTReplay) {
+    args[0].As<Uint8Array>()->Buffer()->TTDRawBufferModifyNotifySync(
+      ts_obj_offset, ts_obj_length);
+  }
 #endif
 }
 

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -50,8 +50,10 @@ NODE_EXTERN void TTDSyncDataModNotify(v8::Local<v8::Object> val,
 // Notify us that a native buffer access (which we don't currently
 // understand/support) happened.
 #define TTD_NATIVE_BUFFER_ACCESS_NOTIFY(X) \
-    JsTTDCheckAndAssertIfTTDRunning( \
-            "Unsupported raw buffer access -- investigate this!!!\n")
+    if (s_doTTRecord || s_doTTReplay) { \
+      JsTTDCheckAndAssertIfTTDRunning( \
+            "Unsupported raw buffer access -- investigate this!!!\n"); \
+    }
 #else
 #define TTD_NATIVE_BUFFER_ACCESS_NOTIFY(X)
 #endif

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -162,7 +162,9 @@ NO_RETURN void FatalError(const char* location, const char* message);
 
 void ProcessEmitWarning(Environment* env, const char* fmt, ...);
 
-void FillStatsArray(v8::Local<v8::Float64Array> fields_array, const uv_stat_t* s, int offset = 0);
+void FillStatsArray(v8::Local<v8::Float64Array> fields_array,
+                    const uv_stat_t* s,
+                    int offset = 0);
 
 void SetupProcessObject(Environment* env,
                         int argc,

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -211,7 +211,9 @@ class ZCtx : public AsyncWrap {
     }
 
 #if ENABLE_TTD_NODE
-    Buffer::TTDAsyncModRegister(out_buf, out);
+    if(s_doTTRecord || s_doTTReplay) {
+      Buffer::TTDAsyncModRegister(out_buf, out);
+    }
 #endif
 
     // async version
@@ -404,7 +406,9 @@ class ZCtx : public AsyncWrap {
     ctx->write_in_progress_ = false;
 
 #if ENABLE_TTD_NODE
-    Buffer::TTDAsyncModNotify(ctx->strm_.next_out);
+    if (s_doTTRecord || s_doTTReplay) {
+      Buffer::TTDAsyncModNotify(ctx->strm_.next_out);
+    }
 #endif
     // call the write() cb
     Local<Value> args[2] = { avail_in, avail_out };
@@ -425,7 +429,9 @@ class ZCtx : public AsyncWrap {
       message = ctx->strm_.msg;
     }
 #if ENABLE_TTD_NODE
-    Buffer::TTDAsyncModNotify(ctx->strm_.next_out);
+    if (s_doTTRecord || s_doTTReplay) {
+      Buffer::TTDAsyncModNotify(ctx->strm_.next_out);
+    }
 #endif
 
     HandleScope scope(env->isolate());

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -191,7 +191,9 @@ Local<Object> SyncProcessStdioPipe::GetOutputAsBuffer(Environment* env) const {
   CopyOutput(Buffer::Data(js_buffer));
 
 #if ENABLE_TTD_NODE
-  Buffer::TTDSyncDataModNotify(js_buffer, 0, length);
+  if (s_doTTRecord || s_doTTReplay) {
+    Buffer::TTDSyncDataModNotify(js_buffer, 0, length);
+  }
 #endif
 
   return js_buffer;

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -74,14 +74,8 @@ TLSWrap::TLSWrap(Environment* env,
   node::Wrap(object(), this);
   MakeWeak(this);
 
-  //
-  //TODO: This is a temp workaround for the stashed persistent pointer in (object()) that is made weak.
-  //      The resulting hidden lifetime means we lose the reference for it in the event replay code. 
-  //      We will need to:
-  //        (1) Add a method to notify the engine that these pointers are being stashed (likely in the persistent code).
-  //        (2) Add GC support to defer collecting objects with callback (and weak sets/maps) to the main event loop when 
-  //            we can force a GC at a known time to handle all of this (and the weak persistent can notify that the stashed pointer is gone).
-  if(s_doTTRecord) {
+  // TODO(marron): This is a temp workaround for the stashed persistent pointer
+  if (s_doTTRecord) {
     unsigned int refct = 0;
     JsAddRef(*(this->object()), &refct);
   }
@@ -840,11 +834,11 @@ void TLSWrap::DestroySSL(const FunctionCallbackInfo<Value>& args) {
   // Destroy the SSL structure and friends
   wrap->SSLWrap<TLSWrap>::DestroySSL();
 
-  //See comment with AddRef earlier in this file.
-  if(s_doTTRecord) {
+  // See comment with AddRef earlier in this file.
+  if (s_doTTRecord) {
       unsigned int refct = 0;
-      //As this is null we may have lost the reference earlier in the run... which coule be bad
-      if(*(wrap->object()) != nullptr) {
+      // As this is null we may have lost the reference earlier in the run...
+      if (*(wrap->object()) != nullptr) {
           JsRelease(*(wrap->object()), &refct);
       }
   }


### PR DESCRIPTION
<!--
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim

##### Description of change
Fix various cpplint warnings (Issue #196).
Add fast checks for "TTD Enabled" around TTD buffer modification calls (Issue #193).

PR-URL: https://github.com/mrkmarron/node-chakracore/commit/5d45e13ad4c8203b9eb5edac0c94e86d2edf18fd