### PR TITLE
chakrashim: enable building with Node ICU on Linux

### DIFF
--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -22,7 +22,7 @@
         'msvs_windows_target_platform_version_prop':
           '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)',
       }],
-      ['OS=="mac"', {
+      ['OS!="win"', {
         'icu_include_path': '../<(icu_path)/source/common'
       }],
 
@@ -42,7 +42,7 @@
       'type': 'none',
 
       'conditions': [
-        ['OS=="mac"', {
+        ['OS!="win"', {
           'dependencies': [
             '<(icu_gyp_path):icui18n',
             '<(icu_gyp_path):icuuc',
@@ -78,11 +78,11 @@
             'chakracore_binaries': [
               '<(chakra_libs_absolute)/lib/libChakraCoreStatic.a',
             ],
+            'icu_args': '--icu=<(icu_include_path)',
             'linker_start_group': '-Wl,--start-group',
             'linker_end_group': [
               '-Wl,--end-group',
               '-lgcc_s',
-              '-licuuc',
             ]
           }],
           ['OS=="mac"', {


### PR DESCRIPTION
https://github.com/nodejs/node-chakracore/pull/185 enabled using Node ICU on OSX. This PR follows with Linux support.

@kunalspathak @digitalinfinity this PR is necessary to use the Linux CI job. OK to fast-track if this looks good to you?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Chakrashim

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
