### PR TITLE
chakrashim: enable multicore build

### DIFF
--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -121,6 +121,7 @@
               'action': [
                 'bash',
                 '<(chakra_dir)/build.sh',
+                '-j',
                 '--without=Simdjs',
                 '--static',
                 '<@(chakra_build_flags)',


### PR DESCRIPTION
Calling `build.sh` with `-j` will make it invoke make with `-j` set to the number of processors available. This is likely a better default than the current `-j1`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

chakrashim
