### PR TITLE
inspector: fixing lambda call frames

### DIFF
--- a/deps/chakrashim/src/jsrtinspectorhelpers.cc
+++ b/deps/chakrashim/src/jsrtinspectorhelpers.cc
@@ -480,26 +480,31 @@ namespace jsrt {
                                                         "thisObject",
                                                         &hasProperty));
 
-    if (hasProperty)
-    {
+    JsValueRef thisObj = nullptr;
+
+    if (hasProperty) {
       JsValueRef thisObject = nullptr;
       CHAKRA_VERIFY_NOERROR(InspectorHelpers::GetProperty(stackProperties,
                                                           "thisObject",
                                                           &thisObject));
-
-      JsValueRef thisObj = nullptr;
       WrapObject(thisObject, &thisObj);
-      CHAKRA_VERIFY_NOERROR(InspectorHelpers::SetProperty(wrappedObj,
-                                                          "this",
-                                                          thisObj));
+    } else {
+      // The protocol requires a "this" member, so create an undefined object
+      // to return.
+      CHAKRA_VERIFY_NOERROR(JsCreateObject(&thisObj));
+      CHAKRA_VERIFY_NOERROR(InspectorHelpers::SetStringProperty(
+          thisObj, "type", "undefined"));
     }
+    
+    CHAKRA_VERIFY_NOERROR(InspectorHelpers::SetProperty(wrappedObj,
+                                                        "this",
+                                                        thisObj));
 
     CHAKRA_VERIFY_NOERROR(InspectorHelpers::HasProperty(stackProperties,
                                                         "returnValue",
                                                         &hasProperty));
 
-    if (hasProperty)
-    {
+    if (hasProperty) {
       JsValueRef returnObj = nullptr;
       CHAKRA_VERIFY_NOERROR(InspectorHelpers::GetProperty(stackProperties,
                                                           "returnValue",


### PR DESCRIPTION
Call frames for a lambda function may not include a "this" object. In
those cases we were omitting the "this" member, but that causes a
validation failure and returns an empty call stack.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
inspector