### PR TITLE
n-api: Fix test-addons-napi failures

### DIFF
--- a/test/addons-napi/test_async/test.js
+++ b/test/addons-napi/test_async/test.js
@@ -3,12 +3,6 @@ const common = require('../../common');
 const assert = require('assert');
 const child_process = require('child_process');
 
-if (common.isChakraEngine) {
-  common.skip('Skipped for node-chakracore till #246 is fixed.');
-  return;
-}
-
-
 const test_async = require(`./build/${common.buildType}/test_async`);
 
 const testException = 'test_async_cb_exception';

--- a/test/addons-napi/test_make_callback_recurse/test.js
+++ b/test/addons-napi/test_make_callback_recurse/test.js
@@ -6,11 +6,6 @@ const domain = require('domain');
 const binding = require(`./build/${common.buildType}/binding`);
 const makeCallback = binding.makeCallback;
 
-if (common.isChakraEngine) {
-  common.skip('Skipped for node-chakracore till #246 is fixed.');
-  return;
-}
-
 // Make sure this is run in the future.
 const mustCallCheckDomains = common.mustCall(checkDomains);
 


### PR DESCRIPTION
 - Reimplement `napi_make_callback()` to call `node::MakeCallback()` using V8 (chakrashim) types. We always knew the direct call to `JsCallFunction()` was incorrect there.
 - Re-enable the two tests that were failing due to `napi_make_callback()`

Fixes: https://github.com/nodejs/node-chakracore/issues/246

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api
