### PR TITLE
n-api: Fix TypedAarray info for ArrayBuffer offset

### DIFF
--- a/src/node_api_jsrt.cc
+++ b/src/node_api_jsrt.cc
@@ -1995,7 +1995,7 @@ napi_status napi_get_typedarray_info(napi_env env,
   }
 
   if (data != nullptr) {
-    *data = static_cast<uint8_t*>(bufferData) + byteOffset;
+    *data = static_cast<uint8_t*>(bufferData);
   }
 
   if (arraybuffer != nullptr) {


### PR DESCRIPTION
The `JsGetTypedArrayStorage()` API returns a buffer pointer that already incorporates the offset into the ArrayBuffer, so adding the offset was a mistake.

This bug was caught by the N-API C++ wrapper tests at https://github.com/nodejs/node-addon-api/blob/master/test/typedarray.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api