### PR TITLE
chakrashim: check return value for inspector call

### DIFF
--- a/deps/chakrashim/src/inspector/v8-debugger-agent-impl.cc
+++ b/deps/chakrashim/src/inspector/v8-debugger-agent-impl.cc
@@ -21,6 +21,7 @@
 #include "src/inspector/v8-stack-trace-impl.h"
 
 #include "include/v8-inspector.h"
+#include "src/jsrtinspector.h"
 #include "src/jsrtinspectorhelpers.h"
 
 namespace v8_inspector {
@@ -205,6 +206,11 @@ bool V8DebuggerAgentImpl::enabled() {
 
 void V8DebuggerAgentImpl::enable(ErrorString* errorString) {
   if (enabled()) return;
+
+  if (!jsrt::Inspector::IsInspectorEnabled()) {
+    *errorString = "Inspector must be enabled at startup";
+    return;
+  }
 
   if (!m_inspector->client()->canExecuteScripts(m_session->contextGroupId())) {
     *errorString = "Script execution is prohibited";


### PR DESCRIPTION
The return value for JsDiagGetScripts was not being validated and
continuing on during an error condition.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim