### PR TITLE
build: restore intl check for inspector

### DIFF
--- a/configure
+++ b/configure
@@ -1307,6 +1307,7 @@ def configure_intl(o):
 
 def configure_inspector(o):
   disable_inspector = (options.without_inspector or
+                       options.with_intl in (None, 'none') or
                        options.without_ssl)
   o['variables']['v8_enable_inspector'] = 0 if disable_inspector else 1
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -303,10 +303,13 @@ static struct {
                     "so event tracing is not available.\n");
   }
   void StopTracingAgent() {}
+#endif  // !NODE_USE_V8_PLATFORM
+
+#if NODE_USE_V8_PLATFORM == 0 || HAVE_INSPECTOR == 0
   bool InspectorStarted(Environment *env) {
     return false;
   }
-#endif  // !NODE_USE_V8_PLATFORM
+#endif  //  !NODE_USE_V8_PLATFORM || !HAVE_INSPECTOR
 } v8_platform;
 
 #ifdef __POSIX__


### PR DESCRIPTION
* Upstream has a check that turns off inspector if intl is also turned
  off. Restoring that check so that without-intl builds will succeed.
* Fixed upstream build break related to disabling inspector, will
  submit upstream PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, src