### PR TITLE
n-api: enable napi_wrap() to work with any object

### DIFF
--- a/src/node_api_jsrt.cc
+++ b/src/node_api_jsrt.cc
@@ -1382,7 +1382,7 @@ napi_status napi_unwrap(napi_env env, napi_value js_object, void** result) {
   bool hasExternalData = false;
   do {
     CHECK_JSRT(JsGetPrototype(wrapper, &wrapper));
-    if (wrapper == nullptr) {
+    if (wrapper == JS_INVALID_REFERENCE) {
       return  napi_invalid_arg;
     }
     CHECK_JSRT(JsHasExternalData(wrapper, &hasExternalData));


### PR DESCRIPTION
Change to inserting an external object into the wrapper object's prototype chain, instead of injecting an alternate `this` object in the constructor callback adapter. The latter approach didn't work in certain scenarios because the JSRT runtime still returned the original `this` object.

And with this change, the setting and checking of the extension flag, which distinguished wrapper objects from external objects, can be removed. I was never happy with that abuse of the extension flag even when I coded it.

Also removing the CallbackInfo.returnValue field which is not used anymore (since we switched to direct return values).

See also my PR at https://github.com/nodejs/node/pull/13250, which gives further details and includes a new test case that validates this change. While it's not included in this PR, I have manually run that test to validate this change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included (at https://github.com/nodejs/node/pull/13250)
- [x] documentation is changed or added (at https://github.com/nodejs/node/pull/13250)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api
