### PR TITLE
deps: pass Windows SDK version to ChakraCore

### DIFF
--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -110,6 +110,7 @@
                 '/p:Configuration=$(ConfigurationName)',
                 '/p:RuntimeLib=<(component)',
                 '/p:AdditionalPreprocessorDefinitions=COMPILE_DISABLE_Simdjs=1',
+                '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)',
                 '/m',
                 '<@(_inputs)',
               ],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This ensures ChakraCore is built with the same Windows SDK as the rest of the project.

CI: https://ci.nodejs.org/view/All/job/chakracore-test/77/

cc @digitalinfinity @kfarnung 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

deps, build, chakracore
