### PR TITLE
chakrashim: fix undefined values in inspector

### DIFF
--- a/deps/chakrashim/src/jsrtinspectorhelpers.cc
+++ b/deps/chakrashim/src/jsrtinspectorhelpers.cc
@@ -22,6 +22,7 @@
 
 #include "v8chakra.h"
 #include "jsrtinspectorhelpers.h"
+#include "jsrtutils.h"
 
 namespace jsrt {
   static const int JsrtDebugPropertyAttributeReadOnly = 4;
@@ -58,6 +59,13 @@ namespace jsrt {
 
     JsValueRef sourceVal = nullptr;
     IfJsErrorRet(JsGetProperty(sourceObj, propId, &sourceVal));
+
+    bool isUndefined;
+    IfJsErrorRet(jsrt::IsUndefined(sourceVal, &isUndefined));
+
+    if (isUndefined) {
+      return JsNoError;
+    }
 
     JsValueRef destVal = nullptr;
     if (convertFunc != nullptr) {


### PR DESCRIPTION
When creating the wrapped objects we were copying the `undefined`
properties which were then being translated to `null` during
serialization.

Fixes #280

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim