### PR TITLE
lib,src: enable TTD record with env variable

### DIFF
--- a/lib/trace_mgr.js
+++ b/lib/trace_mgr.js
@@ -157,6 +157,9 @@ function createTraceLogTarget(tracename) {
   var traceRootDir = emitOptions.localTraceDirectory ||
     path.dirname(process.mainModule.filename);
 
+  // Add the PID to the trace name
+  tracename = `${tracename}_pid${process.pid}`;
+
   var resolvedTracePath =
     path.resolve(traceRootDir, '_diagnosticTraces', tracename);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -4985,6 +4985,15 @@ int Start(int argc, char** argv) {
 #if ENABLE_TTD_NODE
   bool chk_debug_enabled = debug_options.inspector_enabled();
 
+  std::string envDoRecordVar;
+  bool envDoRecord = SafeGetenv("DO_TTD_RECORD", &envDoRecordVar) &&
+      envDoRecordVar[0] == '1';
+
+  if (!s_doTTRecord && !s_doTTReplay) {
+    // Apply the value from the environment variable
+    s_doTTRecord = envDoRecord;
+  }
+
   TTDFlagWarning_Cond(!s_doTTRecord || !s_doTTReplay,
       "Cannot enable record & replay at same time.\n");
 
@@ -5013,6 +5022,11 @@ int Start(int argc, char** argv) {
 
       TTDFlagWarning_Cond(s_ttoptReplayUri != nullptr,
           "Must set replay source info when replaying.\n");
+  }
+
+  if (s_doTTRecord) {
+    // Apply the environment variable to be inherited by child processes.
+    putenv("DO_TTD_RECORD=1");
   }
 #endif
 


### PR DESCRIPTION
* Added support for the `DO_TTD_RECORD` environment variable to start
  recording
* Added code to write the environment variable if `--record` is passed
  to the node command line for child processes to consume
* Added the pid to the trace filename to prevent collisions

Fixes #273

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib, src