### PR TITLE
build: move SDK detection to npm-cli.js

### DIFF
--- a/deps/chakrashim/npm
+++ b/deps/chakrashim/npm
@@ -1,4 +1,0 @@
-#!/bin/bash
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
-export NPM_CONFIG_NODEDIR="$DIR"
-$DIR/lib/node_modules/npm/bin/npm-cli.js "$@"

--- a/deps/npm/bin/npm-cli.js
+++ b/deps/npm/bin/npm-cli.js
@@ -14,6 +14,14 @@
     return
   }
 
+  if (!process.env.NPM_CONFIG_NODEDIR) {
+    if (process.platform === 'win32') {
+      process.env.NPM_CONFIG_NODEDIR = require('path').join(process.execPath, '..', 'sdk')
+    } else {
+      process.env.NPM_CONFIG_NODEDIR = require('path').join(process.execPath, '..', '..')
+    }
+  }
+
   process.title = 'npm'
 
   var unsupported = require('../lib/utils/unsupported.js')

--- a/tools/install.py
+++ b/tools/install.py
@@ -89,8 +89,14 @@ def npm_files(action):
     paths = [os.path.join(dirname, basename) for basename in basenames]
     action(paths, target_path + dirname[9:] + '/')
 
-  # create/remove npm invoke script
-  action(['deps/chakrashim/npm'], 'bin/npm')
+  # create/remove symlink
+  link_path = abspath(install_path, 'bin/npm')
+  if action == uninstall:
+    action([link_path], 'bin/npm')
+  elif action == install:
+    try_symlink('../lib/node_modules/npm/bin/npm-cli.js', link_path)
+  else:
+    assert(0) # unhandled action type
 
 def subdir_files(path, dest, action):
   ret = {}

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -312,12 +312,6 @@ copy /Y node.lib node-v%FULLVERSION%-win-%target_arch%\sdk\%config%\ > nul
 if errorlevel 1 echo Cannot copy node.lib && goto package_error
 copy /Y chakracore.lib node-v%FULLVERSION%-win-%target_arch%\sdk\%config%\ > nul
 if errorlevel 1 echo Cannot copy chakracore.lib && goto package_error
-set "pkgnpmsh=node-v%FULLVERSION%-win-%target_arch%/npm"
-%native_node_exe% -e "var data=fs.readFileSync('%pkgnpmsh%', 'utf8').split('\n');data.splice(-2, 0, 'export NPM_CONFIG_NODEDIR=\"$basedir/sdk\"');fs.writeFileSync('%pkgnpmsh%', data.join('\n'))"
-if errorlevel 1 echo Cannot change %pkgnpmsh% && goto package_error
-set "pkgnpmcmd=node-v%FULLVERSION%-win-%target_arch%/npm.cmd"
-%native_node_exe% -e "var data=fs.readFileSync('%pkgnpmcmd%', 'utf8').split('\n');data.splice(-2, 0, 'SET \"NPM_CONFIG_NODEDIR=%%~dp0\\sdk\"');fs.writeFileSync('%pkgnpmcmd%', data.join('\n'))"
-if errorlevel 1 echo Cannot change %pkgnpmcmd% && goto package_error
 
 echo Creating node-v%FULLVERSION%-win-%target_arch%.7z
 del node-v%FULLVERSION%-win-%target_arch%.7z > nul 2> nul


### PR DESCRIPTION
This change allows bin/npm to be a symlink again in Unix.

This partially reverts commit 64480a53f2d3d9298ae57986301d6c3bd2a8b1, removing all the changes to set the NPM_CONFIG_NODEDIR variable.

`NPM_CONFIG_NODEDIR` is now set in npm-cli.js, this will be necessary until node-gyp can download all the files needed for node-chakracore on its own.

cc @kunalspathak @digitalinfinity 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

build, deps