### PR TITLE
Add missing TTD hooks for async_hooks and update for zlib change (##13322)

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -544,9 +544,18 @@ void AsyncWrap::Initialize(Local<Object> target,
       isolate,
       uid_fields_ptr,
       uid_fields_count * sizeof(*uid_fields_ptr));
+  Local<Float64Array> farray = Float64Array::New(uid_fields_ab, 0, uid_fields_count);
   FORCE_SET_TARGET_FIELD(target,
                          "async_uid_fields",
-                         Float64Array::New(uid_fields_ab, 0, uid_fields_count));
+                         farray);
+
+#if ENABLE_TTD_NODE
+  if (s_doTTRecord || s_doTTReplay) {
+    unsigned int refcount = 0;
+    JsAddRef(*farray, &refcount);
+    env->async_hooks()->uid_fields_ttdRef = *farray;
+  }
+#endif
 
   Local<Object> constants = Object::New(isolate);
 #define SET_HOOKS_CONSTANT(name)                                              \

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -134,6 +134,10 @@ inline void Environment::AsyncHooks::push_ids(double async_id,
                     uid_fields_[kCurrentTriggerId] });
   uid_fields_[kCurrentAsyncId] = async_id;
   uid_fields_[kCurrentTriggerId] = trigger_id;
+
+#if ENABLE_TTD_NODE
+  this->AsyncWrapId_TTDRecord();
+#endif
 }
 
 inline bool Environment::AsyncHooks::pop_ids(double async_id) {
@@ -163,6 +167,11 @@ inline bool Environment::AsyncHooks::pop_ids(double async_id) {
   ids_stack_.pop();
   uid_fields_[kCurrentAsyncId] = ids.async_id;
   uid_fields_[kCurrentTriggerId] = ids.trigger_id;
+
+#if ENABLE_TTD_NODE
+  this->AsyncWrapId_TTDRecord();
+#endif
+
   return !ids_stack_.empty();
 }
 
@@ -171,6 +180,10 @@ inline void Environment::AsyncHooks::clear_id_stack() {
     ids_stack_.pop();
   uid_fields_[kCurrentAsyncId] = 0;
   uid_fields_[kCurrentTriggerId] = 0;
+
+#if ENABLE_TTD_NODE
+  this->AsyncWrapId_TTDRecord();
+#endif
 }
 
 inline Environment::AsyncHooks::InitScope::InitScope(
@@ -430,7 +443,13 @@ inline std::vector<double>* Environment::destroy_ids_list() {
 }
 
 inline double Environment::new_async_id() {
-  return ++async_hooks()->uid_fields()[AsyncHooks::kAsyncUidCntr];
+  double res = ++async_hooks()->uid_fields()[AsyncHooks::kAsyncUidCntr];
+
+#if ENABLE_TTD_NODE
+  this->async_hooks()->AsyncWrapId_TTDRecord();
+#endif
+
+  return res;
 }
 
 inline double Environment::current_async_id() {
@@ -445,12 +464,21 @@ inline double Environment::get_init_trigger_id() {
   double* uid_fields = async_hooks()->uid_fields();
   double tid = uid_fields[AsyncHooks::kInitTriggerId];
   uid_fields[AsyncHooks::kInitTriggerId] = 0;
+
+#if ENABLE_TTD_NODE
+  this->async_hooks()->AsyncWrapId_TTDRecord();
+#endif
+
   if (tid <= 0) tid = current_async_id();
   return tid;
 }
 
 inline void Environment::set_init_trigger_id(const double id) {
   async_hooks()->uid_fields()[AsyncHooks::kInitTriggerId] = id;
+
+#if ENABLE_TTD_NODE
+  this->async_hooks()->AsyncWrapId_TTDRecord();
+#endif
 }
 
 inline double* Environment::heap_statistics_buffer() const {

--- a/src/env.h
+++ b/src/env.h
@@ -369,6 +369,18 @@ class Environment {
       kUidFieldsCount,
     };
 
+#if ENABLE_TTD_NODE
+    //Work around AsyncHooks id hack
+    v8::Float64Array* uid_fields_ttdRef;
+
+    void AsyncWrapId_TTDRecord() {
+      if (s_doTTRecord || s_doTTReplay) {
+        const int modlength = kUidFieldsCount * sizeof(double);
+        uid_fields_ttdRef->Buffer()->TTDRawBufferModifyNotifySync(0, modlength);
+      }
+    }
+#endif
+
     AsyncHooks() = delete;
 
     inline uint32_t* fields();

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -1,4 +1,4 @@
-// Copyright Joyent, Inc. and other Node contributors.
+﻿// Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the
@@ -90,7 +90,8 @@ class ZCtx : public AsyncWrap {
         pending_close_(false),
         refs_(0),
         gzip_id_bytes_read_(0),
-        write_result_(nullptr) {
+        write_result_(nullptr),
+        write_result_ttdBuff(nullptr) {
     MakeWeak<ZCtx>(this);
     Wrap(wrap, this);
   }
@@ -213,6 +214,15 @@ class ZCtx : public AsyncWrap {
         ctx->write_result_[0] = ctx->strm_.avail_out;
         ctx->write_result_[1] = ctx->strm_.avail_in;
         ctx->write_in_progress_ = false;
+
+#if ENABLE_TTD_NODE
+        if (s_doTTRecord || s_doTTReplay) {
+          const size_t modSize = 2 * sizeof(uint32_t);
+          auto ttdbuf = ctx->write_result_ttdBuff->Buffer();
+          ttdbuf->TTDRawBufferModifyNotifySync(0, modSize);
+        }
+#endif
+
         ctx->Unref();
       }
       return;
@@ -221,6 +231,10 @@ class ZCtx : public AsyncWrap {
 #if ENABLE_TTD_NODE
     if (s_doTTRecord || s_doTTReplay) {
       Buffer::TTDAsyncModRegister(out_buf, out);
+
+      v8::Local<v8::ArrayBuffer> ttdbuf = ctx->write_result_ttdBuff->Buffer();
+      byte* ttdraw = (byte*)ttdbuf->GetContents().Data();
+      ttdbuf->TTDRawBufferNotifyRegisterForModification(ttdraw);
     }
 #endif
 
@@ -390,6 +404,11 @@ class ZCtx : public AsyncWrap {
 #if ENABLE_TTD_NODE
     if (s_doTTRecord || s_doTTReplay) {
       Buffer::TTDAsyncModNotify(ctx->strm_.next_out);
+
+      v8::Local<v8::ArrayBuffer> ttdbuf = ctx->write_result_ttdBuff->Buffer();
+      byte* ttdraw = (byte*)ttdbuf->GetContents().Data();
+      const size_t modSize = 2 * sizeof(uint32_t);
+      ttdbuf->TTDRawBufferAsyncModifyComplete(ttdraw + modSize);
     }
 #endif
 
@@ -493,7 +512,7 @@ class ZCtx : public AsyncWrap {
       memcpy(dictionary, dictionary_, dictionary_len);
     }
 
-    Init(ctx, level, windowBits, memLevel, strategy, write_result,
+    Init(ctx, level, windowBits, memLevel, strategy, write_result, *array,
          write_js_callback, dictionary, dictionary_len);
     SetDictionary(ctx);
   }
@@ -513,7 +532,7 @@ class ZCtx : public AsyncWrap {
   }
 
   static void Init(ZCtx *ctx, int level, int windowBits, int memLevel,
-                   int strategy, uint32_t* write_result,
+                   int strategy, uint32_t* write_result, Uint32Array* write_resultTTDBuffer,
                    Local<Function> write_js_callback, char* dictionary,
                    size_t dictionary_len) {
     ctx->level_ = level;
@@ -581,6 +600,10 @@ class ZCtx : public AsyncWrap {
     }
 
     ctx->write_result_ = write_result;
+#if ENABLE_TTD_NODE
+    JsTTDNotifyLongLivedReferenceAdd(write_resultTTDBuffer);
+    ctx->write_result_ttdBuff = write_resultTTDBuffer;
+#endif
     ctx->write_js_callback_.Reset(ctx->env()->isolate(), write_js_callback);
   }
 
@@ -689,6 +712,7 @@ class ZCtx : public AsyncWrap {
   unsigned int refs_;
   unsigned int gzip_id_bytes_read_;
   uint32_t* write_result_;
+  v8::Uint32Array* write_result_ttdBuff; //must be kept alive by host
   Persistent<Function> write_js_callback_;
 };
 


### PR DESCRIPTION
##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
time-travel debugging, zlib, async_hooks

Pull forward changes for TTD to work nicely with async_hooks.
ZLib changes broke TTD but adding a buffer which is modified directly by native code. Add TTD calls to track these modifications.