### PR TITLE
build: split up cpplint to avoid long cmd lines

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -465,12 +465,17 @@ goto cpplint
 
 :cpplint
 if not defined cpplint goto jslint
-echo running cpplint
+call :run-cpplint src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
+call :run-cpplint %chakra_cpplint%
+call :run-python tools/check-imports.py
+goto jslint
+
+:run-cpplint
+if "%*"=="" goto exit
+echo running cpplint '%*'
 set cppfilelist=
 setlocal enabledelayedexpansion
-for /f "tokens=*" %%G in ('dir /b /s /a src\*.c src\*.cc src\*.h ^
-test\addons\*.cc test\addons\*.h test\cctest\*.cc test\cctest\*.h ^
-test\gc\binding.cc tools\icu\*.cc tools\icu\*.h %chakra_cpplint%') do (
+for /f "tokens=*" %%G in ('dir /b /s /a %*') do (
   set relpath=%%G
   set relpath=!relpath:*%~dp0=!
   call :add-to-list !relpath!
@@ -479,8 +484,7 @@ test\gc\binding.cc tools\icu\*.cc tools\icu\*.h %chakra_cpplint%') do (
   set cppfilelist=%localcppfilelist%
 )
 call :run-python tools/cpplint.py %cppfilelist%
-call :run-python tools/check-imports.py
-goto jslint
+goto exit
 
 :add-to-list
 echo %1 | findstr /b /c:"src\node_root_certs.h" > nul 2>&1


### PR DESCRIPTION
* Added a separate cpplint run for chakrashim
* Added `setlocal` to the start of the script to prevent environment
  variables from leaking out

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build