### PR TITLE
Adding LTO support to configure script

### DIFF
--- a/configure
+++ b/configure
@@ -492,6 +492,13 @@ parser.add_option('--chakracore-ninja-build',
     default=False,
     help='Enable build of ChakraCore using ninja (requires engine to be ChakraCore)')
 
+parser.add_option('--chakracore-lto-build',
+    action='store_true',
+    dest='chakracore_lto_build',
+    default=False,
+    help='Enable build of ChakraCore using LTO (requires engine to be ChakraCore)')
+
+
 parser.add_option('--shared',
     action='store_true',
     dest='shared',
@@ -1351,6 +1358,13 @@ def configure_engine(o):
       o['variables']['chakracore_parallel_build_flags'] = [ "--ninja" ]
     else:
       o['variables']['chakracore_parallel_build_flags'] = []
+    if options.chakracore_lto_build:
+      o['variables']['chakracore_use_lto'] = "true"
+      o['variables']['chakracore_lto_build_flags'] = [ "--lto" ]
+    else:
+      o['variables']['chakracore_use_lto'] = "false"
+      o['variables']['chakracore_lto_build_flags'] = [ ]
+
 
 
 output = {

--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -122,6 +122,7 @@
                 '--without=Simdjs',
                 '--static',
                 '<@(chakracore_parallel_build_flags)',
+                '<@(chakracore_lto_build_flags)',
                 '<@(chakra_build_flags)',
                 '<@(icu_args)',
                 '--libs-only'

--- a/node.gyp
+++ b/node.gyp
@@ -272,6 +272,13 @@
           'sources': [
             'src/node_api_jsrt.cc',
           ],
+          'conditions': [
+            [ 'OS!="win" and chakracore_use_lto=="true"', {
+              'ldflags': [
+                '-flto',
+              ],
+            }],
+          ],
         }, {
           'sources': [
             'src/node_api.cc',
@@ -699,7 +706,14 @@
           ],
           'sources!': [
             'test/cctest/test_environment.cc', # TODO: Enable these test for node-chakracore
-          ]
+          ],
+          'conditions': [
+            [ 'OS!="win" and chakracore_use_lto=="true"', {
+              'ldflags': [
+                '-flto',
+              ],
+            }],
+          ],
         }],
         ['v8_enable_inspector==1', {
           'sources': [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Adding the `--chakracore-lto-build` configure flag which will cause it to attempt an LTO build. The system needs to be configured appropriately with compatible versions of `ar`, `ranlib` and `ld`, and node itself must be built with a compiler that understands LLVM, e.g. compiling with `CXX=clang++`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Build