### PR TITLE
chakrashim: using new jsrt JsCopyStringOneByte interface

### DIFF
--- a/deps/chakrashim/src/v8string.cc
+++ b/deps/chakrashim/src/v8string.cc
@@ -101,23 +101,14 @@ int String::Write(uint16_t *buffer, int start, int length, int options) const {
 
 int String::WriteOneByte(
     uint8_t* buffer, int start, int length, int options) const {
-  // The JSRT API only supports utf8 and utf16 encoded strings. In order to get
-  // 8 bit bytes from the string (i.e. Latin1) we can get the utf16 string and
-  // cast each character down to a uint8_t. This will only work for characters
-  // between U+0000 and U+00FF in the source string.
-  uint16_t* tmpBuffer = new uint16_t[length];
   size_t count = 0;
-  if (JsCopyStringUtf16((JsValueRef)this, start, length,
-                        tmpBuffer, &count) == JsNoError) {
-    for (size_t i = 0; i < count; i++) {
-      buffer[i] = (uint8_t)tmpBuffer[i];
-    }
-
-    if (!(options & String::NO_NULL_TERMINATION)) {
-      buffer[count] = 0;
+  if (JsCopyStringOneByte((JsValueRef)this, start, length,
+                          (char *)buffer, &count) == JsNoError) {
+    if (!(options & String::NO_NULL_TERMINATION) &&
+        (length == -1 || count < length)) {
+      buffer[count] = '\0';
     }
   }
-  delete[] tmpBuffer;
   return count;
 }
 


### PR DESCRIPTION
Several scenarios involve moving buffers of 8-bit chars around.
Previously the only way to get 8-bit chars out of jsrt was to get
16-bit chars and then marshal them manually. To assist with this,
we've added a new JsCopyStringOneByte function to directly extract
8-bit strings without needing intermediate storage.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim