### PR TITLE
chakrashim: Avoid calling JsCopyString twice to find length

### DIFF
--- a/deps/chakrashim/src/jsrtutils.cc
+++ b/deps/chakrashim/src/jsrtutils.cc
@@ -976,26 +976,34 @@ StringUtf8::~StringUtf8() {
   }
 }
 
+JsErrorCode StringUtf8::LengthFrom(JsValueRef strRef) {
+    CHAKRA_ASSERT(_length == 0);
+
+    size_t len = 0;
+    IfJsErrorRet(JsCopyString(strRef, nullptr, 0, &len));
+
+    _length = len;
+    return JsNoError;
+}
+
 JsErrorCode StringUtf8::From(JsValueRef strRef) {
   CHAKRA_ASSERT(!_str);
 
-  size_t len = 0;
-  IfJsErrorRet(JsCopyString(strRef, nullptr, 0, &len));
+  IfJsErrorRet(LengthFrom(strRef));
+  size_t len = length();
 
   char* buffer = reinterpret_cast<char*>(malloc(len+1));
   CHAKRA_VERIFY(buffer != nullptr);
 
   size_t written = 0;
-  JsErrorCode errorCode = JsCopyString(strRef, buffer, len, &written);
+  IfJsErrorRet(JsCopyString(strRef, buffer, len, &written));
 
-  if (errorCode == JsNoError) {
-    CHAKRA_ASSERT(len == written);
-    buffer[len] = '\0';
-    _str = buffer;
-    _length = static_cast<int>(len);
-  }
+  CHAKRA_ASSERT(len == written);
+  buffer[len] = '\0';
+  _str = buffer;
+  _length = static_cast<int>(len);
 
-  return errorCode;
+  return JsNoError;
 }
 
 }  // namespace jsrt

--- a/deps/chakrashim/src/jsrtutils.h
+++ b/deps/chakrashim/src/jsrtutils.h
@@ -104,6 +104,9 @@ class StringUtf8 {
   operator const char *() const { return _str; }
   int length() const { return static_cast<int>(_length); }
   JsErrorCode From(JsValueRef strRef);
+  // This just initializes length field. _str will remain uninitialized.
+  // Use `From()` to initialize _str and _length
+  JsErrorCode LengthFrom(JsValueRef strRef);
 
  private:
   // Disallow copying and assigning

--- a/deps/chakrashim/src/v8string.cc
+++ b/deps/chakrashim/src/v8string.cc
@@ -79,11 +79,10 @@ int String::Length() const {
 
 int String::Utf8Length() const {
   jsrt::StringUtf8 str;
-  if (str.From((JsValueRef)this) != JsNoError) {
+  if (str.LengthFrom((JsValueRef)this) != JsNoError) {
     // error
     return 0;
   }
-
   return str.length();
 }
 


### PR DESCRIPTION
To find Utf8Length, we call `JsCopyString()` to find the length
of utf8 string and then another call to actually perform the copy
into the buffer. 2nd call is not needed for just finding length.

Gives approx. 2% win in acme-air on my machine.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim