### PR TITLE
Fix v8 build break

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -83,8 +83,11 @@ inline uint32_t* IsolateData::zero_fill_field() const {
 inline Environment::AsyncHooks::AsyncHooks(v8::Isolate* isolate)
     : isolate_(isolate),
       fields_(),
-      uid_fields_(),
-      uid_fields_ttdRef(nullptr) {
+      uid_fields_()
+#if ENABLE_TTD_NODE
+      ,uid_fields_ttdRef(nullptr)
+#endif
+{
   v8::HandleScope handle_scope(isolate_);
 
   // kAsyncUidCntr should start at 1 because that'll be the id the execution

--- a/test/message/nexttick_throw.v8.out
+++ b/test/message/nexttick_throw.v8.out
@@ -2,11 +2,10 @@
 *test*message*nexttick_throw.js:*
 *undefined_reference_error_maker;
 *^
-ReferenceError: *undefined_reference_error_maker*
+ReferenceError: *undefined_reference_error_maker is not defined*
 *at *test*message*nexttick_throw.js:*:*
 *at _combinedTickCallback (internal/process/next_tick.js:*:*)
 *at *_tickCallback (internal/process/next_tick.js:*:*)
 *at Module.runMain (module.js:*:*)
-*at run (bootstrap_node.js:*:*)
 *at startup (bootstrap_node.js:*:*)
 *at *bootstrap_node.js:*:*

--- a/test/parallel/test-vm-new-script-new-context.js
+++ b/test/parallel/test-vm-new-script-new-context.js
@@ -42,14 +42,16 @@ const Script = require('vm').Script;
 }
 
 {
-  assert.throws(
-    function() {
-      script.runInNewContext();
-    },
-    common.engineSpecificMessage({
-      v8: /^ReferenceError: foo is not defined$/,
-      chakracore: /ReferenceError: Use before declaration/
-    }));
+  const script = new Script('foo.bar = 5;');
+  assert.throws(function() {
+    script.runInNewContext();
+  }, common.engineSpecificMessage({
+    v8: /^ReferenceError: foo is not defined$/,
+    chakracore: /^TypeError: Unable to set property 'bar' of undefined or null reference$/
+  }));
+}
+
+{
   global.hello = 5;
   const script = new Script('hello = 2');
   script.runInNewContext();
@@ -95,14 +97,12 @@ const Script = require('vm').Script;
   script.runInNewContext({ f: f });
   assert.strictEqual(f.a, 2);
 
-  assert.throws(
-    function() {
-      script.runInNewContext();
-    },
-    common.engineSpecificMessage({
-      v8: /^ReferenceError: f is not defined$/,
-      chakracore: /'a' of undefined or null/
-    }));
+  assert.throws(function() {
+    script.runInNewContext();
+  }, common.engineSpecificMessage({
+    v8: /^ReferenceError: f is not defined$/,
+    chakracore: /^TypeError: Unable to set property 'a' of undefined or null reference$/
+  }));
 }
 
 {
@@ -111,6 +111,6 @@ const Script = require('vm').Script;
     script.runInNewContext.call('\'hello\';');
   }, common.engineSpecificMessage({
     v8: /^TypeError: this\.runInContext is not a function$/,
-    chakracore: /TypeError: Object doesn't support property or method 'runInContext'/
+    chakracore: /^TypeError: Object doesn't support property or method 'runInContext'$/
   }));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Addressed v8 build break. Also ran through unit test and fixed 2 test cases. There are still 2 unit test failures in inspector that are failing for node-v8. @kfarnung  might have idea.

* inspector/test-bindings
* inspector/test-off-with-session-then-on

Fixes: #354 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src,test
