### PR TITLE
calling JsAddRef/JsRelease for data passed to SetEmbedderData

### DIFF
--- a/deps/chakrashim/src/jsrtcontextshim.cc
+++ b/deps/chakrashim/src/jsrtcontextshim.cc
@@ -471,6 +471,15 @@ void ContextShim::SetAlignedPointerInEmbedderData(int index, void * value) {
     if (embedderData.size() < minSize) {
       embedderData.resize(minSize);
     }
+
+    // ensure reference counting, otherwise objects can be GC'd.  JsAddRef/
+    // JsRelease will handle cases if the pointer is not valid for ref counts.
+    void * oldValue = embedderData[index];
+    if (oldValue != nullptr) {
+      JsRelease(oldValue, nullptr);
+    }
+    JsAddRef(value, nullptr);
+
     embedderData[index] = value;
   } catch(const std::exception&) {
   }


### PR DESCRIPTION
chakrashim: ref count data sent to SetEmbedderData

JS Objects passed to SetEmbedderData need to have JsAddRef/JsRelease
called, otherwise they could be GC'd prematurely.

Fixes: https://github.com/nodejs/node-chakracore/issues/97

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] ~~tests and/or benchmarks are included~~ *N/A - opened #371 to track getting unit tests up for ChakraShim*
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
chakrashim
