### PR TITLE
chakrashim: removing ObjectPrototypeToStringShim

### DIFF
--- a/deps/chakrashim/src/jsrtcachedpropertyidref.inc
+++ b/deps/chakrashim/src/jsrtcachedpropertyidref.inc
@@ -122,6 +122,8 @@ DEF(type)
 DEF(uncaught)
 DEF(url)
 
+DEF(toStringTag)
+DEF(Symbol_toStringTag)
 
 DEFSYMBOL(self)
 DEFSYMBOL(__external__)

--- a/deps/chakrashim/src/jsrtcontextcachedobj.inc
+++ b/deps/chakrashim/src/jsrtcontextcachedobj.inc
@@ -45,7 +45,7 @@ DEFTYPE(Float32Array)
 DEFTYPE(Float64Array)
 DEFTYPE(RegExp)
 DEFTYPE(Map)
-
+DEFTYPE(Symbol)
 
 
 // These prototype functions will be cached/shimmed

--- a/deps/chakrashim/src/jsrtcontextshim.cc
+++ b/deps/chakrashim/src/jsrtcontextshim.cc
@@ -247,36 +247,6 @@ bool ContextShim::InitializeGlobalPrototypeFunctions() {
   return true;
 }
 
-// Replace (cached) Object.prototype.toString with a shim to support
-// ObjectTemplate class name. Called after InitializeGlobalPrototypeFunctions().
-bool ContextShim::InitializeObjectPrototypeToStringShim() {
-  IsolateShim* iso = GetIsolateShim();
-
-  JsValueRef objectPrototype;
-  if (JsGetProperty(GetObjectConstructor(),
-                    iso->GetCachedPropertyIdRef(CachedPropertyIdRef::prototype),
-                    &objectPrototype) != JsNoError) {
-    return false;
-  }
-
-  JsValueRef function;
-  if (JsCreateFunction(v8::Utils::ObjectPrototypeToStringShim,
-                       GetGlobalPrototypeFunction(
-                         GlobalPrototypeFunction::Object_toString),
-                       &function) != JsNoError) {
-    return false;
-  }
-
-  if (JsSetProperty(objectPrototype,
-                    iso->GetCachedPropertyIdRef(CachedPropertyIdRef::toString),
-                    function, false) != JsNoError) {
-    return false;
-  }
-
-  globalPrototypeFunction[GlobalPrototypeFunction::Object_toString] = function;
-  return true;
-}
-
 bool ContextShim::InitializeBuiltIns() {
   // No need to keep the global object alive, the context will implicitly
   if (JsGetGlobalObject(&globalObject) != JsNoError) {
@@ -319,9 +289,6 @@ bool ContextShim::InitializeBuiltIns() {
     return false;
   }
   if (!InitializeGlobalPrototypeFunctions()) {
-    return false;
-  }
-  if (!InitializeObjectPrototypeToStringShim()) {
     return false;
   }
 
@@ -642,40 +609,3 @@ CHAKRASHIM_FUNCTION_GETTER(jsonStringify);
 #undef DEF_IS_TYPE
 
 }  // namespace jsrt
-
-namespace v8 {
-
-// This shim wraps Object.prototype.toString to supports ObjectTemplate class
-// name.
-JsValueRef CHAKRA_CALLBACK Utils::ObjectPrototypeToStringShim(
-    JsValueRef callee,
-    bool isConstructCall,
-    JsValueRef *arguments,
-    unsigned short argumentCount,  // NOLINT(runtime/int)
-    void *callbackState) {
-  if (argumentCount >= 1) {
-    Isolate* iso = Isolate::GetCurrent();
-    HandleScope scope(iso);
-
-    Object* obj = static_cast<Object*>(arguments[0]);
-    ObjectTemplate* objTemplate = obj->GetObjectTemplate();
-    if (objTemplate) {
-      Local<String> str = objTemplate->GetClassName();
-      if (!str.IsEmpty()) {
-        str = String::Concat(String::NewFromUtf8(iso, "[object "), str);
-        str = String::Concat(str, String::NewFromUtf8(iso, "]"));
-        return *str;
-      }
-    }
-  }
-
-  JsValueRef function = callbackState;
-  JsValueRef result;
-  if (JsCallFunction(function, arguments, argumentCount,
-                     &result) != JsNoError) {
-    return JS_INVALID_REFERENCE;
-  }
-  return result;
-}
-
-}  // namespace v8

--- a/deps/chakrashim/src/jsrtcontextshim.h
+++ b/deps/chakrashim/src/jsrtcontextshim.h
@@ -104,7 +104,6 @@ class ContextShim {
   bool InitializeBuiltIns();
   bool InitializeProxyOfGlobal();
   bool InitializeGlobalPrototypeFunctions();
-  bool InitializeObjectPrototypeToStringShim();
 
   template <typename Fn>
   bool InitializeBuiltIn(JsValueRef * builtInValue, Fn getBuiltIn);

--- a/deps/chakrashim/src/jsrtisolateshim.cc
+++ b/deps/chakrashim/src/jsrtisolateshim.cc
@@ -534,6 +534,24 @@ JsPropertyIdRef IsolateShim::GetCachedPropertyIdRef(
   });
 }
 
+JsPropertyIdRef IsolateShim::GetToStringTagSymbolPropertyIdRef() {
+  return GetCachedPropertyId(cachedPropertyIdRefs, CachedPropertyIdRef::Symbol_toStringTag,
+                             [this](CachedPropertyIdRef index, JsPropertyIdRef* propIdRef) {
+    JsValueRef toStringTagSymbol;
+    if (JsGetProperty(this->GetCurrentContextShim()->GetGlobalType(ContextShim::GlobalType::Symbol),
+                      this->GetCachedPropertyIdRef(jsrt::CachedPropertyIdRef::toStringTag),
+                      &toStringTagSymbol) != JsNoError) {
+      return false;
+    }
+    
+    if (JsGetPropertyIdFromSymbol(toStringTagSymbol, propIdRef) != JsNoError) {
+      return false;
+    }
+    return true;
+  });
+}
+
+
 JsPropertyIdRef IsolateShim::GetProxyTrapPropertyIdRef(ProxyTraps trap) {
   return GetCachedPropertyIdRef(GetProxyTrapCachedPropertyIdRef(trap));
 }

--- a/deps/chakrashim/src/jsrtisolateshim.h
+++ b/deps/chakrashim/src/jsrtisolateshim.h
@@ -94,6 +94,7 @@ class IsolateShim {
 
   // Symbols propertyIdRef
   JsPropertyIdRef GetSelfSymbolPropertyIdRef();
+  JsPropertyIdRef GetToStringTagSymbolPropertyIdRef();
   JsPropertyIdRef GetKeepAliveObjectSymbolPropertyIdRef();
   JsPropertyIdRef GetCachedSymbolPropertyIdRef(
     CachedSymbolPropertyIdRef cachedSymbolPropertyIdRef);

--- a/deps/chakrashim/src/v8chakra.h
+++ b/deps/chakrashim/src/v8chakra.h
@@ -210,13 +210,6 @@ class Utils {
   static void CHAKRA_CALLBACK WeakReferenceCallbackWrapperCallback(
       JsRef ref, void *data);
 
-  static JsValueRef CHAKRA_CALLBACK ObjectPrototypeToStringShim(
-      JsValueRef callee,
-      bool isConstructCall,
-      JsValueRef *arguments,
-      unsigned short argumentCount,  // NOLINT(runtime/int)
-      void *callbackState);
-
   // Create a Local<T> internally (use private constructor)
   template <class T>
   static Local<T> ToLocal(T* that) {

--- a/deps/chakrashim/src/v8functiontemplate.cc
+++ b/deps/chakrashim/src/v8functiontemplate.cc
@@ -237,10 +237,11 @@ class FunctionTemplateData : public TemplateData {
         return nullptr;
       }
 
-      JsValueRef function;
+      Local<String> className = !instanceTemplate.IsEmpty() ?
+        instanceTemplate->GetClassName() : Local<String>();
+
+      JsValueRef function = nullptr;
       {
-        Local<String> className = !instanceTemplate.IsEmpty() ?
-            instanceTemplate->GetClassName() : Local<String>();
         if (!className.IsEmpty()) {
           error = JsCreateNamedFunction(*className,
                                         FunctionCallbackData::FunctionInvoked,
@@ -271,6 +272,19 @@ class FunctionTemplateData : public TemplateData {
                               &parentPrototype) != JsNoError ||
                 JsSetPrototype(*prototype,
                                parentPrototype) != JsNoError) {
+              return nullptr;
+            }
+          }
+
+          if (!className.IsEmpty()) {
+            if (jsrt::DefineProperty(*prototype,
+                iso->GetToStringTagSymbolPropertyIdRef(),
+                jsrt::PropertyDescriptorOptionValues::True, /* writable */
+                jsrt::PropertyDescriptorOptionValues::False, /* enumerable */
+                jsrt::PropertyDescriptorOptionValues::True, /* configurable */
+                *className,
+                JS_INVALID_REFERENCE,
+                JS_INVALID_REFERENCE) != JsNoError) {
               return nullptr;
             }
           }

--- a/deps/chakrashim/src/v8objecttemplate.cc
+++ b/deps/chakrashim/src/v8objecttemplate.cc
@@ -748,7 +748,6 @@ Local<Object> ObjectTemplate::NewInstance(Handle<Object> prototype) {
     }
   }
 
-
   // In case the object should support index or named properties interceptors,
   // we will use Proxies We will also support in case there is an overrdien
   // toString method on the intercepted object (like Buffer), by returning an


### PR DESCRIPTION
To support usage of `v8::FunctionTemplate::className` chakrashim provided
a custom Object.prototype.toString that would require JSRT call out
into an external function, and then most of the time return back into
JSRT to use the defualt function.

The only use of this function was to print `'[object Foo]'` instead of
`'[object Object]'` if an object had been created from a FunctionTemplate
with a ClassName set to `'Foo'`. With this change, we no longer set a
new toString method on the Object prototype, instead we set the
`Symbol.toStringTag` property on the prototype to the appropriate string.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

chakrashim