### PR TITLE
build: fix ./configure --xcode failure

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -412,7 +412,7 @@
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
+          'MACOSX_DEPLOYMENT_TARGET': '10.9',       # -mmacosx-version-min=10.9
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',

--- a/configure
+++ b/configure
@@ -1472,8 +1472,11 @@ write('config.mk', do_not_edit + config)
 
 gyp_args = ['--no-parallel']
 
+chakracore_dir_absolute = os.path.realpath(os.path.dirname(__file__) + '/deps/chakrashim/core')
+
 if options.use_xcode:
   gyp_args += ['-f', 'xcode']
+  chakracore_dir_absolute = '$(PROJECT_DIR)/core'
 elif options.use_ninja:
   gyp_args += ['-f', 'ninja']
 elif flavor == 'win' and sys.platform != 'msys':
@@ -1485,6 +1488,7 @@ if options.compile_commands_json:
   gyp_args += ['-f', 'compile_commands_json']
 
 gyp_args += args
+gyp_args += ['-Dchakracore_dir_absolute=' + chakracore_dir_absolute]
 
 if warn.warned:
   warn('warnings were emitted in the configure phase')

--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -9,6 +9,7 @@
     'linker_start_group%': '',
     'linker_end_group%': '',
     'chakra_libs_absolute%': '',
+    'chakracore_dir_absolute%': '',
 
     # xplat (non-win32) only
     'chakra_config': '<(chakracore_build_config)',     # Debug, Release, Test
@@ -61,7 +62,8 @@
         'chakracore_win_bin_dir':
           '<(chakra_dir)/build/vcbuild/bin/<(Platform)_<(chakracore_build_config)',
         'xplat_dir': '<(chakra_dir)/out/<(chakra_config)',
-        'chakra_libs_absolute': '<(PRODUCT_DIR)/../../deps/chakrashim/<(xplat_dir)',
+        'chakra_libs_absolute': '<(chakracore_dir_absolute)/out/<(chakra_config)', 
+          #'<(PRODUCT_DIR)/../../deps/chakrashim/<(xplat_dir)',
 
         'conditions': [
           ['OS=="win"', {
@@ -147,20 +149,28 @@
         'library_dirs': [ '<(PRODUCT_DIR)' ],
         'conditions': [
           ['OS=="win"', {
-          }, {
-            'conditions': [
-              ['OS=="mac"', {
-                'libraries': [
-                  '-framework CoreFoundation',
-                  '-framework Security',
-                ]
-              }]
+          }, 
+          'OS=="mac"', {
+            'libraries': [
+              # '-Wl,-undefined,error',
+              '$(SDKROOT)/System/Library/Frameworks/CoreFoundation.framework',
+              '$(SDKROOT)/System/Library/Frameworks/Security.framework',
+              # '<@(linker_start_group)',
+              '<(PRODUCT_DIR)/libChakraCoreStatic.a'
+              # '<@(linker_end_group)', # gpy fails to patch with list
             ],
+            'xcode_settings': {
+              'OTHER_LDFLAGS': [
+                '-framework CoreFoundation',
+                '-framework Security',
+              ],
+            },
+          }, {
             'libraries': [
               '-Wl,-undefined,error',
               '<@(linker_start_group)',
-              '<(chakra_libs_absolute)/lib/libChakraCoreStatic.a ' # keep this single space.
-              '<@(linker_end_group)',                                         # gpy fails to patch with list
+              '<(PRODUCT_DIR)/libChakraCoreStatic.a ' # keep this single space.
+              '<@(linker_end_group)', # gpy fails to patch with list
             ],
           }],
         ],


### PR DESCRIPTION
make `./configure --xcode` is able to generate `.xcodeproj` and build all targets successfully

reference: https://github.com/nodejs/node-chakracore/issues/297

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
None
