### PR TITLE
TTD - undoing custom TTD tracking for async-wrap state

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -535,18 +535,10 @@ void AsyncWrap::Initialize(Local<Object> target,
       isolate,
       uid_fields_ptr,
       uid_fields_count * sizeof(*uid_fields_ptr));
-  Local<Float64Array> farray = Float64Array::New(uid_fields_ab, 0,
-                                                 uid_fields_count);
   FORCE_SET_TARGET_FIELD(target,
                          "async_uid_fields",
-                         farray);
-
-#if ENABLE_TTD_NODE
-  if (s_doTTRecord || s_doTTReplay) {
-    JsTTDNotifyLongLivedReferenceAdd(*farray);
-    env->async_hooks()->uid_fields_ttdRef = *farray;
-  }
-#endif
+                         Float64Array::New(uid_fields_ab, 0,
+                         uid_fields_count));
 
   Local<Object> constants = Object::New(isolate);
 #define SET_HOOKS_CONSTANT(name)                                              \

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -84,9 +84,6 @@ inline Environment::AsyncHooks::AsyncHooks(v8::Isolate* isolate)
     : isolate_(isolate),
       fields_(),
       uid_fields_()
-#if ENABLE_TTD_NODE
-    , uid_fields_ttdRef(nullptr)
-#endif
 {
   v8::HandleScope handle_scope(isolate_);
 
@@ -138,10 +135,6 @@ inline void Environment::AsyncHooks::push_ids(double async_id,
                     uid_fields_[kCurrentTriggerId] });
   uid_fields_[kCurrentAsyncId] = async_id;
   uid_fields_[kCurrentTriggerId] = trigger_id;
-
-#if ENABLE_TTD_NODE
-  this->AsyncWrapId_TTDRecord();
-#endif
 }
 
 inline bool Environment::AsyncHooks::pop_ids(double async_id) {
@@ -171,11 +164,6 @@ inline bool Environment::AsyncHooks::pop_ids(double async_id) {
   ids_stack_.pop();
   uid_fields_[kCurrentAsyncId] = ids.async_id;
   uid_fields_[kCurrentTriggerId] = ids.trigger_id;
-
-#if ENABLE_TTD_NODE
-  this->AsyncWrapId_TTDRecord();
-#endif
-
   return !ids_stack_.empty();
 }
 
@@ -188,10 +176,6 @@ inline void Environment::AsyncHooks::clear_id_stack() {
     ids_stack_.pop();
   uid_fields_[kCurrentAsyncId] = 0;
   uid_fields_[kCurrentTriggerId] = 0;
-
-#if ENABLE_TTD_NODE
-  this->AsyncWrapId_TTDRecord();
-#endif
 }
 
 inline Environment::AsyncHooks::InitScope::InitScope(
@@ -464,13 +448,7 @@ inline std::vector<double>* Environment::destroy_ids_list() {
 }
 
 inline double Environment::new_async_id() {
-  double res = ++async_hooks()->uid_fields()[AsyncHooks::kAsyncUidCntr];
-
-#if ENABLE_TTD_NODE
-  this->async_hooks()->AsyncWrapId_TTDRecord();
-#endif
-
-  return res;
+  return ++async_hooks()->uid_fields()[AsyncHooks::kAsyncUidCntr];
 }
 
 inline double Environment::current_async_id() {
@@ -486,20 +464,12 @@ inline double Environment::get_init_trigger_id() {
   double tid = uid_fields[AsyncHooks::kInitTriggerId];
   uid_fields[AsyncHooks::kInitTriggerId] = 0;
 
-#if ENABLE_TTD_NODE
-  this->async_hooks()->AsyncWrapId_TTDRecord();
-#endif
-
   if (tid <= 0) tid = current_async_id();
   return tid;
 }
 
 inline void Environment::set_init_trigger_id(const double id) {
   async_hooks()->uid_fields()[AsyncHooks::kInitTriggerId] = id;
-
-#if ENABLE_TTD_NODE
-  this->async_hooks()->AsyncWrapId_TTDRecord();
-#endif
 }
 
 inline double* Environment::heap_statistics_buffer() const {

--- a/src/env.h
+++ b/src/env.h
@@ -388,17 +388,6 @@ class Environment {
       kUidFieldsCount,
     };
 
-#if ENABLE_TTD_NODE
-    // Work around AsyncHooks id hack
-    v8::Float64Array* uid_fields_ttdRef;
-
-    void AsyncWrapId_TTDRecord() {
-      if ((s_doTTRecord || s_doTTReplay) && (uid_fields_ttdRef != nullptr)) {
-        const int modlength = kUidFieldsCount * sizeof(double);
-        uid_fields_ttdRef->Buffer()->TTDRawBufferModifyNotifySync(0, modlength);
-      }
-    }
-#endif
 
     AsyncHooks() = delete;
 


### PR DESCRIPTION
undoing custom TTD tracking around async-wrap to eliminate merge
conflicts and set up for using AliasedBuffer to track these
changes.  Once AliasedBuffer is merged in, we'll do the TTD
tracking in AliasedBuffer's SetValue() method.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
TTD, async-wrap