### PR TITLE
ttd: adding ttd tracking logic to aliased_buffer

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -234,6 +234,7 @@
         'src/base-object-inl.h',
         'src/connection_wrap.h',
         'src/connect_wrap.h',
+        'src/chakra_ttd.h',
         'src/env.h',
         'src/env-inl.h',
         'src/handle_wrap.h',

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -2,6 +2,7 @@
 #ifndef SRC_ALIASED_BUFFER_H_
 #define SRC_ALIASED_BUFFER_H_
 
+#include "chakra_ttd.h"
 #include "v8.h"
 #include "util.h"
 #include "util-inl.h"
@@ -164,6 +165,14 @@ class AliasedBuffer {
     CHECK_LT(index, count_);
 #endif
     buffer_[index] = value;
+
+#if defined(ENABLE_TTD_NODE) && ENABLE_TTD_NODE
+    if (s_doTTRecord || s_doTTReplay) {
+      const int modlength = count_ * sizeof(NativeT);
+      GetArrayBuffer()->TTDRawBufferModifyNotifySync(byte_offset_, modlength);
+    }
+#endif
+
   }
 
   /**

--- a/src/chakra_ttd.h
+++ b/src/chakra_ttd.h
@@ -1,0 +1,16 @@
+#ifndef SRC_CHAKRA_TTD_H_
+#define SRC_CHAKRA_TTD_H_
+
+#if defined(NODE_ENGINE_CHAKRACORE)
+#define ENABLE_TTD_NODE 1
+#else
+#define ENABLE_TTD_NODE 0
+#endif
+
+#if defined(ENABLE_TTD_NODE) && ENABLE_TTD_NODE
+extern bool s_doTTRecord;
+extern bool s_doTTReplay;
+extern bool s_doTTDebug;
+#endif
+
+#endif  // SRC_CHAKRA_TTD_H_

--- a/src/node.h
+++ b/src/node.h
@@ -96,17 +96,7 @@
 // Forward-declare libuv loop
 struct uv_loop_s;
 
-#if defined(NODE_ENGINE_CHAKRACORE)
-#define ENABLE_TTD_NODE 1
-#else
-#define ENABLE_TTD_NODE 0
-#endif
-
-#if ENABLE_TTD_NODE
-extern bool s_doTTRecord;
-extern bool s_doTTReplay;
-extern bool s_doTTDebug;
-#endif
+#include "chakra_ttd.h"
 
 // Forward-declare these functions now to stop MSVS from becoming
 // terminally confused when it's done in node_internals.h


### PR DESCRIPTION
Whenever state modifications happen outside of JSRT API calls, we need
to to track them to for TTD to correctly track state.  This change
updates aliased_buffer's SetValue() method to do the correct TTD
tracking.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
ttd
