### PR TITLE
test: fixing AliasedBuffer tests to enter Isolate

### DIFF
--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -82,6 +82,7 @@ void ReadAndValidate(v8::Isolate* isolate,
 
 template<class NativeT, class V8T>
 void ReadWriteTest(v8::Isolate* isolate) {
+  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = v8::Context::New(isolate);
   v8::Context::Scope context_scope(context);
@@ -114,6 +115,7 @@ void SharedBufferTest(
     size_t count_A,
     size_t count_B,
     size_t count_C) {
+  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = v8::Context::New(isolate);
   v8::Context::Scope context_scope(context);


### PR DESCRIPTION
AliasedBuffer tests weren't creating an v8::Isolate::Scope, and this
had negative impact on the node-chakracore branch, where expectation
is an Isoalte has been Enter()'d before being used.

Same as https://github.com/nodejs/node/pull/15536.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
