### PR TITLE
test: fixing test_general to work with imprecise GC

### DIFF
--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -59,9 +59,12 @@ assert.strictEqual(test_general.testNapiTypeof(null), 'null');
 
 // Ensure that garbage collecting an object with a wrapped native item results
 // in the finalize callback being called.
-let w = {};
-test_general.wrap(w);
-w = null;
+function createAndForgetWrap() {
+  let w = {};
+  test_general.wrap(w);
+  w = null;
+}
+createAndForgetWrap();
 global.gc();
 assert.strictEqual(test_general.derefItemWasCalled(), true,
                    'deref_item() was called upon garbage collecting a ' +


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
The weak reference problem of #380 has been addressed upstream in the test which will no longer expect to take a weak reference to non-objects. The test was still failing due to an object not being GCd when the test expected it to. There was an interpreter frame which was keeping the object alive, so the GC didn't clean up the object. By encapsulating it in a function we ensure that when we GC there is no lingering reference.

fixes #380
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test