### PR TITLE
chakrashim: improve hot path calls

### DIFF
--- a/deps/chakrashim/src/v8object.cc
+++ b/deps/chakrashim/src/v8object.cc
@@ -717,7 +717,9 @@ JsErrorCode Utils::GetObjectData(Object* object, ObjectData** objectData) {
   {
     JsPropertyIdRef selfSymbolIdRef =
       jsrt::IsolateShim::GetCurrent()->GetSelfSymbolPropertyIdRef();
-    if (selfSymbolIdRef != JS_INVALID_REFERENCE) {
+    bool hasSelf = false;
+    if (JsHasProperty(object, selfSymbolIdRef, &hasSelf) != JsNoError &&
+        hasSelf == true) {
       JsValueRef result;
       error = JsGetProperty(object, selfSymbolIdRef, &result);
       if (error != JsNoError) {

--- a/deps/chakrashim/src/v8value.cc
+++ b/deps/chakrashim/src/v8value.cc
@@ -45,11 +45,11 @@ static bool IsOfType(const Value* ref, JsValueType type) {
 }
 
 bool Value::IsUndefined() const {
-  return IsOfType(this, JsValueType::JsUndefined);
+  return this == jsrt::GetUndefined();
 }
 
 bool Value::IsNull() const {
-  return IsOfType(this, JsValueType::JsNull);
+  return this == jsrt::GetNull();
 }
 
 bool Value::IsNullOrUndefined() const {
@@ -57,21 +57,11 @@ bool Value::IsNullOrUndefined() const {
 }
 
 bool Value::IsTrue() const {
-  bool isTrue;
-  if (JsEquals(jsrt::GetTrue(), (JsValueRef)this, &isTrue) != JsNoError) {
-    return false;
-  }
-
-  return isTrue;
+  return this == jsrt::GetTrue();
 }
 
 bool Value::IsFalse() const {
-  bool isFalse;
-  if (JsEquals(jsrt::GetFalse(), (JsValueRef)this, &isFalse) != JsNoError) {
-    return false;
-  }
-
-  return isFalse;
+  return this == jsrt::GetFalse();
 }
 
 bool Value::IsString() const {


### PR DESCRIPTION
 - Context has the cached `null` and `undefined` pointer references. Use them instead of going for type discovery. These two are on the hot path.

 - Number of times this call is successful is merely 0 yet it's in the middle of a `GetObjectData` hot path. If `object` is not proxy, we are able to do `HasProperty` discovery without really entering into script. So.. `JsHasProperty` is reasonably faster than `JsGetProperty + isUndefined`
calls.