### PR TITLE
build: fix node-chakracore arm build

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -279,6 +279,14 @@
               }],
             ],
           }],
+          ['target_arch=="arm"', {
+            'TargetMachine' : 3, # /MACHINE:ARM
+            'target_conditions': [
+              ['_type=="executable"', {
+                'AdditionalOptions': [ '/SubSystem:Console,"6.02"' ],
+              }],
+            ],
+          }],
         ],
         'GenerateDebugInformation': 'true',
         'GenerateMapFile': 'true', # /MAP

--- a/node.gyp
+++ b/node.gyp
@@ -871,7 +871,7 @@
             'deps/v8/include'
           ],
           'conditions' : [
-            ['node_use_v8_platform=="true"', {
+            ['node_use_v8_platform=="true" and node_engine=="v8"', {
               'dependencies': [
                 'deps/v8/src/v8.gyp:v8_libplatform',
               ],
@@ -961,6 +961,7 @@
         [ 'OS=="win"', {
           'libraries': [
             '<(OBJ_PATH)<(OBJ_SEPARATOR)backtrace_win32.<(OBJ_SUFFIX)',
+             '-ldbghelp.lib'
            ],
         }, {
           'libraries': [
@@ -987,7 +988,7 @@
             'deps/uv/uv.gyp:libuv'
           ]
         }],
-        [ 'node_use_v8_platform=="true"', {
+        [ 'node_use_v8_platform=="true" and node_engine=="v8"', {
           'dependencies': [
             'deps/v8/src/v8.gyp:v8_libplatform',
           ],


### PR DESCRIPTION
1. Exclude v8 gyp dependency if building node-chakracore
2. Explicitly specify CONSOLE subsystem for windows arm builds
3. Explicitly depend on dbghelp for cctest (since v8 was implicitly pulling in that dependency before)

Note that I'm still seeing some tests failing but I think that is the same failure that @MSLaguana was seeing?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build