### PR TITLE
test: skip tests that are marked flaky for node-chakracore

### DIFF
--- a/test/abort/abort.status
+++ b/test/abort/abort.status
@@ -1,4 +1,4 @@
-prefix async-hooks
+prefix abort
 
 # To mark a test as flaky, list the test name in the appropriate section
 # below, without ".js", followed by ": PASS,FLAKY". Example:
@@ -12,18 +12,13 @@ prefix async-hooks
 
 [$system==macos]
 
-[$arch==arm || $arch==arm64]
-
-[$system==solaris] # Also applies to SmartOS
+[$system==solaris]
 
 [$system==freebsd]
 
-[$jsEngine==chakracore]
-# These tests are failing for Node-Chakracore and should eventually be fixed
-test-promise : SKIP
-test-promise.chain-promise-before-init-hooks : SKIP
-test-promise.promise-before-init-hooks : SKIP
+[$system==aix]
 
+[$jsEngine==chakracore]
 # This test is disabled for chakra engine because it depends
 # on v8-option --abort-on-uncaught-exception
-test-callback-error : SKIP
+test-abort-uncaught-exception : SKIP

--- a/test/abort/test-abort-uncaught-exception.js
+++ b/test/abort/test-abort-uncaught-exception.js
@@ -5,12 +5,6 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const node = process.execPath;
 
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine because it depends ' +
-              'on v8-option --abort-on-uncaught-exception');
-  return;
-}
-
 if (process.argv[2] === 'child') {
   throw new Error('child error');
 } else {

--- a/test/addons-napi/addons-napi.status
+++ b/test/addons-napi/addons-napi.status
@@ -19,4 +19,5 @@ prefix addons-napi
 [$system==aix]
 
 [$jsEngine==chakracore]
-test_env_sharing/test : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test_env_sharing/test : SKIP

--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -19,8 +19,9 @@ prefix addons
 [$system==aix]
 
 [$jsEngine==chakracore]
-async-hooks-promise/test : PASS,FLAKY
-hello-world-esm/test : PASS,FLAKY
-new-target/test : PASS,FLAKY
-callback-scope/test : PASS,FLAKY
-callback-scope/test-resolve-async : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+async-hooks-promise/test : SKIP
+hello-world-esm/test : SKIP
+new-target/test : SKIP
+callback-scope/test : SKIP
+callback-scope/test-resolve-async : SKIP

--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -25,3 +25,8 @@ hello-world-esm/test : SKIP
 new-target/test : SKIP
 callback-scope/test : SKIP
 callback-scope/test-resolve-async : SKIP
+
+# This test is disabled for chakra engine because it depends
+# on v8 GC behavior. Chakra GC may find reference-like data
+# on native stack and may not do the GC as expected.
+null-buffer-neuter/test : SKIP

--- a/test/addons/null-buffer-neuter/test.js
+++ b/test/addons/null-buffer-neuter/test.js
@@ -4,11 +4,4 @@
 const common = require('../../common');
 const binding = require(`./build/${common.buildType}/binding`);
 
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine because it depends ' +
-              'on v8 GC behavior. Chakra GC may find reference-like data ' +
-              'on native stack and may not do the GC as expected.');
-  return;
-}
-
 binding.run();

--- a/test/async-hooks/async-hooks.status
+++ b/test/async-hooks/async-hooks.status
@@ -19,6 +19,7 @@ prefix async-hooks
 [$system==freebsd]
 
 [$jsEngine==chakracore]
-test-promise : PASS,FLAKY
-test-promise.chain-promise-before-init-hooks : PASS,FLAKY
-test-promise.promise-before-init-hooks : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-promise : SKIP
+test-promise.chain-promise-before-init-hooks : SKIP
+test-promise.promise-before-init-hooks : SKIP

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -5,12 +5,6 @@ const { spawnSync, fork } = require('child_process');
 const async_hooks = require('async_hooks');
 const initHooks = require('./init-hooks');
 
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine because it depends ' +
-              'on v8-option --abort-on-uncaught-exception');
-  return;
-}
-
 const arg = process.argv[2];
 switch (arg) {
   case 'test_init_callback':

--- a/test/es-module/es-module.status
+++ b/test/es-module/es-module.status
@@ -7,23 +7,24 @@ prefix es-module
 [true] # This section applies to all platforms
 
 [$jsEngine==chakracore]
-test-esm-basic-imports : PASS,FLAKY
-test-esm-double-encoding : PASS,FLAKY
-test-esm-encoded-path : PASS,FLAKY
-test-esm-encoded-path-native : PASS,FLAKY
-test-esm-example-loader : PASS,FLAKY
-test-esm-forbidden-globals : PASS,FLAKY
-test-esm-json : PASS,FLAKY
-test-esm-loader-dependency : PASS,FLAKY
-test-esm-loader-modulemap : PASS,FLAKY
-test-esm-named-exports : PASS,FLAKY
-test-esm-namespace : PASS,FLAKY
-test-esm-ok : PASS,FLAKY
-test-esm-preserve-symlinks : PASS,FLAKY
-test-esm-preserve-symlinks-not-found : PASS,FLAKY
-test-esm-preserve-symlinks-not-found-plain : PASS,FLAKY
-test-esm-require-cache : PASS,FLAKY
-test-esm-resolve-hook : PASS,FLAKY
-test-esm-shebang : PASS,FLAKY
-test-esm-snapshot : PASS,FLAKY
-test-esm-symlink : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-esm-basic-imports : SKIP
+test-esm-double-encoding : SKIP
+test-esm-encoded-path : SKIP
+test-esm-encoded-path-native : SKIP
+test-esm-example-loader : SKIP
+test-esm-forbidden-globals : SKIP
+test-esm-json : SKIP
+test-esm-loader-dependency : SKIP
+test-esm-loader-modulemap : SKIP
+test-esm-named-exports : SKIP
+test-esm-namespace : SKIP
+test-esm-ok : SKIP
+test-esm-preserve-symlinks : SKIP
+test-esm-preserve-symlinks-not-found : SKIP
+test-esm-preserve-symlinks-not-found-plain : SKIP
+test-esm-require-cache : SKIP
+test-esm-resolve-hook : SKIP
+test-esm-shebang : SKIP
+test-esm-snapshot : SKIP
+test-esm-symlink : SKIP

--- a/test/es-module/es-module.status
+++ b/test/es-module/es-module.status
@@ -7,7 +7,6 @@ prefix es-module
 [true] # This section applies to all platforms
 
 [$jsEngine==chakracore]
-test-esm-addon : PASS,FLAKY
 test-esm-basic-imports : PASS,FLAKY
 test-esm-double-encoding : PASS,FLAKY
 test-esm-encoded-path : PASS,FLAKY

--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -21,7 +21,3 @@ test-cluster-disconnect-handles: SKIP
 [$system==aix]
 
 [$jsEngine==chakracore]
-test-vm-attributes-property-not-on-sandbox : PASS,FLAKY
-test-vm-data-property-writable : PASS,FLAKY
-test-vm-inherited_properties : PASS,FLAKY
-test-vm-strict-mode : PASS,FLAKY

--- a/test/message/message.status
+++ b/test/message/message.status
@@ -17,5 +17,6 @@ prefix message
 [$system==freebsd]
 
 [$jsEngine==chakracore]
-console_low_stack_space : PASS,FLAKY
-unhandled_promise_trace_warnings : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+console_low_stack_space : SKIP
+unhandled_promise_trace_warnings : SKIP

--- a/test/message/message.status
+++ b/test/message/message.status
@@ -18,5 +18,4 @@ prefix message
 
 [$jsEngine==chakracore]
 console_low_stack_space : PASS,FLAKY
-stack_overflow_async : PASS,FLAKY
 unhandled_promise_trace_warnings : PASS,FLAKY

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -116,6 +116,21 @@ test-vm-strict-assign : SKIP
 # https://github.com/nodejs/node-chakracore/issues/395
 test-zlib-empty-buffer : SKIP
 
+# These tests are disabled for chakra engine because they depend
+# on v8-option --abort-on-uncaught-exception
+test-domain-throw-error-then-throw-from-uncaught-exception-handler : SKIP
+test-domain-with-abort-on-uncaught-exception : SKIP
+
+# These tests are disabled for chakra engine because they depend
+# on v8 flag --allow_natives_syntax
+test-v8-flags : SKIP
+test-v8-version-tag : SKIP
+
+# This test is disabled for chakra engine because it depends
+# on v8-option --max-old-space-size
+test-windows-failed-heap-allocation : SKIP
+
+
 [$jsEngine==chakracore && $arch==x64]
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-buffer-includes : SKIP

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -28,15 +28,12 @@ test-async-hooks-enable-during-promise : PASS,FLAKY
 test-async-hooks-promise : PASS,FLAKY
 test-async-hooks-promise-enable-disable : PASS,FLAKY
 test-async-hooks-promise-triggerid : PASS,FLAKY
-test-async-wrap-getasyncid : PASS,FLAKY
 test-async-wrap-promise-after-enabled : PASS,FLAKY
 test-buffer-bindingobj-no-zerofill : PASS,FLAKY
 test-buffer-sharedarraybuffer : PASS,FLAKY
 test-child-process-promisified : PASS,FLAKY
-test-cluster-inspector-debug-port : PASS,FLAKY
 test-crypto-dh : PASS,FLAKY
 test-crypto-dh-leak : PASS,FLAKY
-test-debugger-repeat-last : PASS,FLAKY
 test-domain-abort-on-uncaught : PASS,FLAKY
 test-domain-no-error-handler-abort-on-uncaught-0 : PASS,FLAKY
 test-domain-no-error-handler-abort-on-uncaught-1 : PASS,FLAKY
@@ -57,7 +54,6 @@ test-http2-client-promisify-connect : PASS,FLAKY
 test-http2-server-rst-stream : PASS,FLAKY
 test-inspect-async-hook-setup-at-inspect : PASS,FLAKY
 test-intl : PASS,FLAKY
-test-intl-no-icu-data : PASS,FLAKY
 test-memory-usage : PASS,FLAKY
 test-module-main-extension-lookup : PASS,FLAKY
 test-performance-function : PASS,FLAKY

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,56 +22,57 @@ test-npm-install:      PASS,FLAKY
 [$system==aix]
 
 [$jsEngine==chakracore]
-test-assert-checktag : PASS,FLAKY
-test-async-hooks-disable-during-promise : PASS,FLAKY
-test-async-hooks-enable-during-promise : PASS,FLAKY
-test-async-hooks-promise : PASS,FLAKY
-test-async-hooks-promise-enable-disable : PASS,FLAKY
-test-async-hooks-promise-triggerid : PASS,FLAKY
-test-async-wrap-promise-after-enabled : PASS,FLAKY
-test-buffer-bindingobj-no-zerofill : PASS,FLAKY
-test-buffer-sharedarraybuffer : PASS,FLAKY
-test-child-process-promisified : PASS,FLAKY
-test-crypto-dh : PASS,FLAKY
-test-crypto-dh-leak : PASS,FLAKY
-test-domain-abort-on-uncaught : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-0 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-1 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-2 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-3 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-4 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-5 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-6 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-7 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-8 : PASS,FLAKY
-test-domain-no-error-handler-abort-on-uncaught-9 : PASS,FLAKY
-test-domain-promise : PASS,FLAKY
-test-fs-promisified : PASS,FLAKY
-test-fs-stat : PASS,FLAKY
-test-http-pipeline-flood : PASS,FLAKY
-test-http-same-map : PASS,FLAKY
-test-http2-client-promisify-connect : PASS,FLAKY
-test-http2-server-rst-stream : PASS,FLAKY
-test-inspect-async-hook-setup-at-inspect : PASS,FLAKY
-test-intl : PASS,FLAKY
-test-memory-usage : PASS,FLAKY
-test-module-main-extension-lookup : PASS,FLAKY
-test-performance-function : PASS,FLAKY
-test-performance-gc : PASS,FLAKY
-test-process-env-symbols : PASS,FLAKY
-test-promise-internal-creation : PASS,FLAKY
-test-promises-unhandled-rejections : PASS,FLAKY
-test-promises-unhandled-symbol-rejections : PASS,FLAKY
-test-promises-warning-on-unhandled-rejection : PASS,FLAKY
-test-regress-GH-12371 : PASS,FLAKY
-test-repl : PASS,FLAKY
-test-repl-mode : PASS,FLAKY
-test-repl-pretty-custom-stack : PASS,FLAKY
-test-repl-pretty-stack : PASS,FLAKY
-test-repl-sigint : PASS,FLAKY
-test-repl-tab-complete : PASS,FLAKY
-test-string-decoder : PASS,FLAKY
-test-timers-promisified : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-assert-checktag : SKIP
+test-async-hooks-disable-during-promise : SKIP
+test-async-hooks-enable-during-promise : SKIP
+test-async-hooks-promise : SKIP
+test-async-hooks-promise-enable-disable : SKIP
+test-async-hooks-promise-triggerid : SKIP
+test-async-wrap-promise-after-enabled : SKIP
+test-buffer-bindingobj-no-zerofill : SKIP
+test-buffer-sharedarraybuffer : SKIP
+test-child-process-promisified : SKIP
+test-crypto-dh : SKIP
+test-crypto-dh-leak : SKIP
+test-domain-abort-on-uncaught : SKIP
+test-domain-no-error-handler-abort-on-uncaught-0 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-1 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-2 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-3 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-4 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-5 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-6 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-7 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-8 : SKIP
+test-domain-no-error-handler-abort-on-uncaught-9 : SKIP
+test-domain-promise : SKIP
+test-fs-promisified : SKIP
+test-fs-stat : SKIP
+test-http-pipeline-flood : SKIP
+test-http-same-map : SKIP
+test-http2-client-promisify-connect : SKIP
+test-http2-server-rst-stream : SKIP
+test-inspect-async-hook-setup-at-inspect : SKIP
+test-intl : SKIP
+test-memory-usage : SKIP
+test-module-main-extension-lookup : SKIP
+test-performance-function : SKIP
+test-performance-gc : SKIP
+test-process-env-symbols : SKIP
+test-promise-internal-creation : SKIP
+test-promises-unhandled-rejections : SKIP
+test-promises-unhandled-symbol-rejections : SKIP
+test-promises-warning-on-unhandled-rejection : SKIP
+test-regress-GH-12371 : SKIP
+test-repl : SKIP
+test-repl-mode : SKIP
+test-repl-pretty-custom-stack : SKIP
+test-repl-pretty-stack : SKIP
+test-repl-sigint : SKIP
+test-repl-tab-complete : SKIP
+test-string-decoder : SKIP
+test-timers-promisified : SKIP
 
 # ChakraCore does not support the chrome tracing framework
 test-trace-events-all : PASS,SKIP
@@ -81,57 +82,61 @@ test-trace-events-category-used : PASS,SKIP
 test-trace-events-none : PASS,SKIP
 test-trace-events-v8 : PASS,SKIP
 
-test-url-domain-ascii-unicode : PASS,FLAKY
-test-util : PASS,FLAKY
-test-util-format-shared-arraybuffer : PASS,FLAKY
-test-util-inspect-proxy : PASS,FLAKY
-test-util-promisify : PASS,FLAKY
-test-v8-serdes : PASS,FLAKY
-test-v8-serdes-sharedarraybuffer : PASS,FLAKY
-test-vm-cached-data : PASS,FLAKY
-test-vm-context : PASS,FLAKY
-test-vm-create-and-run-in-context : PASS,FLAKY
-test-vm-debug-context : PASS,FLAKY
-test-vm-global-identity : PASS,FLAKY
-test-vm-low-stack-space : PASS,FLAKY
-test-vm-preserves-property : PASS,FLAKY
-test-vm-property-not-on-sandbox : PASS,FLAKY
-test-vm-sigint : PASS,FLAKY
-test-vm-sigint-existing-handler : PASS,FLAKY
-test-vm-strict-mode : PASS,FLAKY
-test-vm-timeout : PASS,FLAKY
-test-zlib-convenience-methods : PASS,FLAKY
-test-vm-attributes-property-not-on-sandbox : PASS,FLAKY
-test-vm-function-declaration : PASS,FLAKY
-test-vm-getters : PASS,FLAKY
-test-vm-global-define-property : PASS,FLAKY
-test-vm-global-non-writable-properties : PASS,FLAKY
-test-vm-global-property-interceptors : PASS,FLAKY
-test-vm-harmony-symbols : PASS,FLAKY
-test-vm-indexed-properties : PASS,FLAKY
-test-vm-proxies : PASS,FLAKY
-test-vm-strict-assign : PASS,FLAKY
+test-url-domain-ascii-unicode : SKIP
+test-util : SKIP
+test-util-format-shared-arraybuffer : SKIP
+test-util-inspect-proxy : SKIP
+test-util-promisify : SKIP
+test-v8-serdes : SKIP
+test-v8-serdes-sharedarraybuffer : SKIP
+test-vm-cached-data : SKIP
+test-vm-context : SKIP
+test-vm-create-and-run-in-context : SKIP
+test-vm-debug-context : SKIP
+test-vm-global-identity : SKIP
+test-vm-low-stack-space : SKIP
+test-vm-preserves-property : SKIP
+test-vm-property-not-on-sandbox : SKIP
+test-vm-sigint : SKIP
+test-vm-sigint-existing-handler : SKIP
+test-vm-strict-mode : SKIP
+test-vm-timeout : SKIP
+test-zlib-convenience-methods : SKIP
+test-vm-attributes-property-not-on-sandbox : SKIP
+test-vm-function-declaration : SKIP
+test-vm-getters : SKIP
+test-vm-global-define-property : SKIP
+test-vm-global-non-writable-properties : SKIP
+test-vm-global-property-interceptors : SKIP
+test-vm-harmony-symbols : SKIP
+test-vm-indexed-properties : SKIP
+test-vm-proxies : SKIP
+test-vm-strict-assign : SKIP
 
 # https://github.com/nodejs/node-chakracore/issues/395
-test-zlib-empty-buffer : PASS,FLAKY
+test-zlib-empty-buffer : SKIP
 
 [$jsEngine==chakracore && $arch==x64]
-test-buffer-includes : PASS,FLAKY
-test-buffer-indexof : PASS,FLAKY
-test-buffer-slow : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-buffer-includes : SKIP
+test-buffer-indexof : SKIP
+test-buffer-slow : SKIP
 
 [$jsEngine==chakracore && $system==win32]
-test-module-loading-globalpaths : PASS,FLAKY
-test-http-client-get-url : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-module-loading-globalpaths : SKIP
+test-http-client-get-url : SKIP
 
 [$jsEngine==chakracore && $system==linux]
-test-repl-sigint-nested-eval : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-repl-sigint-nested-eval : SKIP
 
 # https://github.com/Microsoft/ChakraCore/issues/3561
-test-wasm-simple : PASS,FLAKY
+test-wasm-simple : SKIP
 
 [$jsEngine==chakracore && $system==macos]
-test-repl-sigint-nested-eval : PASS,FLAKY
-test-vm-sigint : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-repl-sigint-nested-eval : SKIP
+test-vm-sigint : SKIP
 # https://github.com/Microsoft/ChakraCore/issues/3561
-test-wasm-simple : PASS,FLAKY
+test-wasm-simple : SKIP

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -130,6 +130,10 @@ test-v8-version-tag : SKIP
 # on v8-option --max-old-space-size
 test-windows-failed-heap-allocation : SKIP
 
+# This test is disabled for chakra engine because debugger
+# support is not implemented yet.
+test-preload : SKIP
+
 
 [$jsEngine==chakracore && $arch==x64]
 # These tests are failing for Node-Chakracore and should eventually be fixed

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -10,12 +10,6 @@ const assert = require('assert');
 const child_process = require('child_process');
 const domain = require('domain');
 
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine because it depends ' +
-              'on v8-option --abort-on-uncaught-exception');
-  return;
-}
-
 const uncaughtExceptionHandlerErrMsg = 'boom from uncaughtException handler';
 const domainErrMsg = 'boom from domain';
 

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -26,12 +26,6 @@ const fs = require('fs');
  * not --abort_on_uncaught_exception is passed on the command line.
  */
 
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine because it depends ' +
-              'on v8-option --abort-on-uncaught-exception');
-  return;
-}
-
 const domainErrHandlerExMessage = 'exception from domain error handler';
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -8,10 +8,6 @@ if (common.isSunOS)
 
 const assert = require('assert');
 const childProcess = require('child_process');
-if (common.isChakraEngine)
-  common.skip('This test is disabled for chakra engine because debugger ' +
-              'support is not implemented yet.');
-
 
 const nodeBinary = process.argv[0];
 

--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -1,13 +1,8 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const v8 = require('v8');
 const vm = require('vm');
-
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine.');
-  return;
-}
 
 // Note: changing V8 flags after an isolate started is not guaranteed to work.
 // Specifically here, V8 may cache compiled scripts between the flip of the

--- a/test/parallel/test-v8-version-tag.js
+++ b/test/parallel/test-v8-version-tag.js
@@ -1,12 +1,7 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const v8 = require('v8');
-
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine.');
-  return;
-}
 
 const versionTag1 = v8.cachedDataVersionTag();
 assert.strictEqual(typeof versionTag1, 'number');

--- a/test/parallel/test-windows-failed-heap-allocation.js
+++ b/test/parallel/test-windows-failed-heap-allocation.js
@@ -5,10 +5,6 @@ const common = require('../common');
 
 if (!common.isWindows) return common.skip('Windows-only');
 
-if (common.isChakraEngine)
-  common.skip('This test is disabled for chakra engine because it depends ' +
-              'on v8-option --max-old-space-size');
-
 const assert = require('assert');
 const { exec } = require('child_process');
 

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -31,8 +31,14 @@ test-inspector-async-hook-setup-at-inspect-brk : SKIP
 test-inspector-async-stack-traces-promise-then : SKIP
 test-inspector-async-stack-traces-set-interval : SKIP
 test-inspector-break-when-eval : SKIP
-test-inspector-scriptparsed-context : SKIP
 test-inspector-stop-profile-after-done : SKIP
+
+# This test is causing hangs in CI for some reason.
+test-inspector-contexts : SKIP
+
+# This test is disabled for chakra engine because the test
+# hangs after trying to parse in a new context
+test-inspector-scriptparsed-context : SKIP
 
 [$jsEngine==chakracore && $system==linux]
 # These tests are failing for Node-Chakracore and should eventually be fixed

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -23,15 +23,17 @@ test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
 [$system==aix]
 
 [$jsEngine==chakracore]
-test-vm-timeout-rethrow : PASS,FLAKY
-test-benchmark-child-process : PASS,FLAKY
-test-async-wrap-getasyncid : PASS,FLAKY
-test-inspector-async-hook-setup-at-inspect-brk : PASS,FLAKY
-test-inspector-async-stack-traces-promise-then : PASS,FLAKY
-test-inspector-async-stack-traces-set-interval : PASS,FLAKY
-test-inspector-break-when-eval : PASS,FLAKY
-test-inspector-scriptparsed-context : PASS,FLAKY
-test-inspector-stop-profile-after-done : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-vm-timeout-rethrow : SKIP
+test-benchmark-child-process : SKIP
+test-async-wrap-getasyncid : SKIP
+test-inspector-async-hook-setup-at-inspect-brk : SKIP
+test-inspector-async-stack-traces-promise-then : SKIP
+test-inspector-async-stack-traces-set-interval : SKIP
+test-inspector-break-when-eval : SKIP
+test-inspector-scriptparsed-context : SKIP
+test-inspector-stop-profile-after-done : SKIP
 
 [$jsEngine==chakracore && $system==linux]
-test-child-process-pass-fd : PASS,FLAKY
+# These tests are failing for Node-Chakracore and should eventually be fixed
+test-child-process-pass-fd : SKIP

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -59,9 +59,5 @@ async function testBreakpointHit() {
   await pausedPromise;
 }
 
-if (common.isChakraEngine) {
-  common.skip('This test is causing hangs in CI for some reason.');
-}
-
 common.crashOnUnhandledRejection();
 testContextCreatedAndDestroyed().then(testBreakpointHit);

--- a/test/sequential/test-inspector-scriptparsed-context.js
+++ b/test/sequential/test-inspector-scriptparsed-context.js
@@ -5,11 +5,6 @@ common.crashOnUnhandledRejection();
 const { NodeInstance } = require('../common/inspector-helper.js');
 const assert = require('assert');
 
-if (common.isChakraEngine) {
-  common.skip('This test is disabled for chakra engine because the test ' +
-              'hangs after trying to parse in a new context');
-}
-
 const script = `
   'use strict';
   const assert = require('assert');


### PR DESCRIPTION
Currently, most tests that are marked as `FLAKY` for the `ChakraCore` engine in the tests' `.status` files are actually failing everytime they are run.

This PR marks those tests as `SKIP`, instead. `FLAKY` should be used for tests that fail only sometimes due to timing or racing conditions issues but pass most of the time.
This PR contains four different changes, divided by commit:
- Remove, in the `.status` files, mentions to tests that no longer exist.
- Skip tests that are described as `FLAKY` for Node-Chakracore in the `.status` files.
- Skip, in the `.status` files, tests that are being skipped at runtime for depending on V8 features.
- Move the remaining tests that are skipped for Node-Chakracore at runtime to SKIP entries in `.status` files.

Fixes: https://github.com/nodejs/node-chakracore/issues/426

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test