### PR TITLE
chakrashim: fixing ObjectTemplate implementation

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -2366,12 +2366,12 @@ struct IndexedPropertyHandlerConfiguration {
 
 class V8_EXPORT ObjectTemplate : public Template {
  public:
-  static Local<ObjectTemplate> New(Isolate* isolate);
+  static Local<ObjectTemplate> New(
+      Isolate* isolate,
+      Local<FunctionTemplate> constructor = Local<FunctionTemplate>());
 
   V8_DEPRECATE_SOON("Use maybe version", Local<Object> NewInstance());
   V8_WARN_UNUSED_RESULT MaybeLocal<Object> NewInstance(Local<Context> context);
-
-  void SetClassName(Handle<String> name);
 
   void SetAccessor(Handle<String> name,
                    AccessorGetterCallback getter,
@@ -2423,12 +2423,13 @@ class V8_EXPORT ObjectTemplate : public Template {
                                 Handle<Value> data = Handle<Value>());
 
  private:
+  friend class FunctionTemplate;
   friend class FunctionCallbackData;
   friend class FunctionTemplateData;
   friend class Utils;
 
   Local<Object> NewInstance(Handle<Object> prototype);
-  Handle<String> GetClassName();
+  void SetConstructor(Handle<FunctionTemplate> constructor);
 };
 
 class V8_EXPORT External : public Value {

--- a/deps/chakrashim/src/v8objecttemplate.cc
+++ b/deps/chakrashim/src/v8objecttemplate.cc
@@ -27,23 +27,23 @@ class ObjectTemplateData : public TemplateData {
   static const ExternalDataTypes ExternalDataType =
       ExternalDataTypes::ObjectTemplateData;
 
-  Persistent<String> className;
-
   SetterGetterInterceptor * setterGetterInterceptor;
   FunctionCallback functionCallDelegate;
   Persistent<Value> functionCallDelegateInterceptorData;
+  Persistent<FunctionTemplate> constructor;
   int internalFieldCount;
 
-  ObjectTemplateData()
+  explicit ObjectTemplateData(Handle<FunctionTemplate> constructor)
       : TemplateData(ExternalDataType),
         setterGetterInterceptor(nullptr),
         functionCallDelegate(nullptr),
         functionCallDelegateInterceptorData(nullptr),
+        constructor(*constructor),
         internalFieldCount(0) {
   }
 
   ~ObjectTemplateData() {
-      className.Reset();
+      constructor.Reset();
 
       if (setterGetterInterceptor != nullptr) {
         setterGetterInterceptor->namedPropertyInterceptorData.Reset();
@@ -822,9 +822,10 @@ JsValueRef CHAKRA_CALLBACK Utils::DefinePropertyCallback(
   return jsrt::GetTrue();
 }
 
-Local<ObjectTemplate> ObjectTemplate::New(Isolate* isolate) {
+Local<ObjectTemplate> ObjectTemplate::New(Isolate* isolate,
+                                          Local<FunctionTemplate> constructor) {
   JsValueRef objectTemplateRef;
-  ObjectTemplateData* templateData = new ObjectTemplateData();
+  ObjectTemplateData* templateData = new ObjectTemplateData(constructor);
 
   if (JsCreateExternalObject(templateData,
                              ObjectTemplateData::FinalizeCallback,
@@ -866,6 +867,27 @@ Local<Object> ObjectTemplate::NewInstance(Handle<Object> prototype) {
                              &newInstanceRef) != JsNoError) {
     delete objectData;
     return Local<Object>();
+  }
+
+  // If there was no prototype specifically provided, then try to get one from
+  // the constructor, if it exists.  It's possible that the constructor
+  // function doesn't have a prototype to provide.
+  if (prototype.IsEmpty()) {
+    if (!objectTemplateData->constructor.IsEmpty()) {
+      Local<Function> function = objectTemplateData->constructor->GetFunction();
+
+      if (!function.IsEmpty()) {
+        jsrt::IsolateShim* iso = jsrt::IsolateShim::GetCurrent();
+        JsValueRef prototypeValue = nullptr;
+
+        if (JsGetProperty(*function,
+                          iso->GetCachedPropertyIdRef(
+                              jsrt::CachedPropertyIdRef::prototype),
+                          &prototypeValue) == JsNoError) {
+          prototype = Local<Object>::New(prototypeValue);
+        }
+      }
+    }
   }
 
   if (!prototype.IsEmpty()) {
@@ -1096,24 +1118,14 @@ void ObjectTemplate::SetInternalFieldCount(int value) {
   objectTemplateData->internalFieldCount = value;
 }
 
-void ObjectTemplate::SetClassName(Handle<String> className) {
+void ObjectTemplate::SetConstructor(Handle<FunctionTemplate> constructor) {
   ObjectTemplateData* objectTemplateData = nullptr;
   if (!ExternalData::TryGet(this, &objectTemplateData)) {
     CHAKRA_ASSERT(false);  // This should never happen
     return;
   }
 
-  objectTemplateData->className = className;
-}
-
-Handle<String> ObjectTemplate::GetClassName() {
-  ObjectTemplateData* objectTemplateData = nullptr;
-  if (!ExternalData::TryGet(this, &objectTemplateData)) {
-    CHAKRA_ASSERT(false);  // This should never happen
-    return Handle<String>();
-  }
-
-  return objectTemplateData->className;
+  objectTemplateData->constructor = constructor;
 }
 
 }  // namespace v8


### PR DESCRIPTION
It's possible to create an object template with a constructor in V8,
but we didn't support it.  It's a little weird (even in V8) since
objects constructed this way will never trigger the CallHandler of the
FunctionTemplate object, it just inherits the prototype from it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim