### PR TITLE
chakrashim: fix inspector evaluate

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -351,6 +351,7 @@ class Local {
   friend class PropertyDescriptor;
   friend class Proxy;
   friend class RegExp;
+  friend class Set;
   friend class Signature;
   friend class Script;
   friend class StackFrame;

--- a/deps/chakrashim/src/inspector/v8-console.cc
+++ b/deps/chakrashim/src/inspector/v8-console.cc
@@ -839,11 +839,13 @@ V8Console::CommandLineAPIScope::~CommandLineAPIScope() {
     v8::Local<v8::Value> name;
     if (!names->Get(m_context, i).ToLocal(&name) || !name->IsName()) continue;
     if (name->IsString()) {
-      v8::Local<v8::Value> descriptor;
-      bool success = m_global
-                         ->GetOwnPropertyDescriptor(
-                             m_context, v8::Local<v8::Name>::Cast(name))
-                         .ToLocal(&descriptor);
+      // Trigger the accessorGetterCallback to do the delete. This ensures that
+      // the correct property is being deleted. It's possible (though unlikely)
+      // that some other code (or the user) has replaced these properties before
+      // they were able to be cleaned up.
+      v8::Local<v8::Value> value;
+      bool success = m_global->Get(m_context, v8::Local<v8::Name>::Cast(name))
+          .ToLocal(&value);
       DCHECK(success);
       USE(success);
     }

--- a/deps/chakrashim/src/inspector/v8-debugger.cc
+++ b/deps/chakrashim/src/inspector/v8-debugger.cc
@@ -278,7 +278,7 @@ JavaScriptCallFrames V8Debugger::currentCallFrames(int limit) {
   }
 
   JsValueRef stackTrace = JS_INVALID_REFERENCE;
-  JsDiagGetStackTrace(&stackTrace);
+  CHAKRA_VERIFY_NOERROR(JsDiagGetStackTrace(&stackTrace));
 
   unsigned int length = 0;
   CHAKRA_VERIFY_NOERROR(jsrt::GetArrayLength(stackTrace, &length));

--- a/deps/chakrashim/src/jsrtcachedpropertyidref.inc
+++ b/deps/chakrashim/src/jsrtcachedpropertyidref.inc
@@ -125,6 +125,9 @@ DEF(url)
 DEF(toStringTag)
 DEF(Symbol_toStringTag)
 
+DEF(add)
+DEF(from)
+
 DEFSYMBOL(self)
 DEFSYMBOL(__external__)
 DEFSYMBOL(__hiddenvalues__)

--- a/deps/chakrashim/src/jsrtcontextcachedobj.inc
+++ b/deps/chakrashim/src/jsrtcontextcachedobj.inc
@@ -46,16 +46,19 @@ DEFTYPE(Float64Array)
 DEFTYPE(RegExp)
 DEFTYPE(Map)
 DEFTYPE(Symbol)
+DEFTYPE(Set)
 
 
 // These prototype functions will be cached/shimmed
 DEFMETHOD(Object,         toString)
 DEFMETHOD(Object,         valueOf)
 DEFMETHOD(String,         concat)
+DEFMETHOD(Array,          from)
 DEFMETHOD(Array,          push)
 DEFMETHOD(Map,            get)
 DEFMETHOD(Map,            set)
 DEFMETHOD(Map,            has)
+DEFMETHOD(Set,            add)
 
 
 #undef DEFTYPE

--- a/deps/chakrashim/src/jsrtcontextshim.cc
+++ b/deps/chakrashim/src/jsrtcontextshim.cc
@@ -532,6 +532,10 @@ DECLARE_GETOBJECT(ProxyConstructor,
                   globalConstructor[GlobalType::Proxy])
 DECLARE_GETOBJECT(MapConstructor,
                   globalConstructor[GlobalType::Map])
+DECLARE_GETOBJECT(SetConstructor,
+                  globalConstructor[GlobalType::Set])
+DECLARE_GETOBJECT(ArrayConstructor,
+                  globalConstructor[GlobalType::Array])
 DECLARE_GETOBJECT(ToStringFunction,
                   globalPrototypeFunction[GlobalPrototypeFunction
                     ::Object_toString])
@@ -541,6 +545,9 @@ DECLARE_GETOBJECT(ValueOfFunction,
 DECLARE_GETOBJECT(StringConcatFunction,
                   globalPrototypeFunction[GlobalPrototypeFunction
                     ::String_concat])
+DECLARE_GETOBJECT(ArrayFromFunction,
+                  globalPrototypeFunction[GlobalPrototypeFunction
+                    ::Array_from])
 DECLARE_GETOBJECT(ArrayPushFunction,
                   globalPrototypeFunction[GlobalPrototypeFunction
                     ::Array_push])
@@ -553,6 +560,9 @@ DECLARE_GETOBJECT(MapSetFunction,
 DECLARE_GETOBJECT(MapHasFunction,
                   globalPrototypeFunction[GlobalPrototypeFunction
                     ::Map_has])
+DECLARE_GETOBJECT(SetAddFunction,
+                  globalPrototypeFunction[GlobalPrototypeFunction
+                    ::Set_add])
 
 
 JsValueRef ContextShim::GetProxyOfGlobal() {

--- a/deps/chakrashim/src/jsrtcontextshim.h
+++ b/deps/chakrashim/src/jsrtcontextshim.h
@@ -79,17 +79,21 @@ class ContextShim {
   JsValueRef GetRegExpConstructor();
   JsValueRef GetProxyConstructor();
   JsValueRef GetMapConstructor();
+  JsValueRef GetSetConstructor();
+  JsValueRef GetArrayConstructor();
   JsValueRef GetGlobalType(GlobalType index);
 
   JsValueRef GetToStringFunction();
   JsValueRef GetValueOfFunction();
   JsValueRef GetStringConcatFunction();
+  JsValueRef GetArrayFromFunction();
   JsValueRef GetArrayPushFunction();
   JsValueRef GetGlobalPrototypeFunction(GlobalPrototypeFunction index);
   JsValueRef GetProxyOfGlobal();
   JsValueRef GetMapGetFunction();
   JsValueRef GetMapSetFunction();
   JsValueRef GetMapHasFunction();
+  JsValueRef GetSetAddFunction();
 
   void * GetAlignedPointerFromEmbedderData(int index);
   void SetAlignedPointerInEmbedderData(int index, void * value);

--- a/deps/chakrashim/src/jsrtinspectorhelpers.cc
+++ b/deps/chakrashim/src/jsrtinspectorhelpers.cc
@@ -630,6 +630,22 @@ namespace jsrt {
     return EvaluateOnCallFrame(ordinal, expression, returnByValue, isError);
   }
 
+  v8::Local<v8::Value> InspectorHelpers::EvaluateOnGlobalCallFrame(
+      JsValueRef expression, bool returnByValue, bool* isError) {
+    JsValueRef stackTrace = JS_INVALID_REFERENCE;
+    JsErrorCode err = JsDiagGetStackTrace(&stackTrace);
+    if (err == JsErrorDiagNotAtBreak) {
+      return v8::Local<v8::Value>();
+    }
+
+    CHAKRA_VERIFY_NOERROR(err);
+
+    unsigned int length = 0;
+    CHAKRA_VERIFY_NOERROR(jsrt::GetArrayLength(stackTrace, &length));
+
+    return EvaluateOnCallFrame(length - 1, expression, returnByValue, isError);
+  }
+
   v8::Local<v8::Value> InspectorHelpers::GetScriptSource(
       unsigned int scriptId) {
     JsValueRef scriptSource = JS_INVALID_REFERENCE;

--- a/deps/chakrashim/src/jsrtinspectorhelpers.h
+++ b/deps/chakrashim/src/jsrtinspectorhelpers.h
@@ -53,6 +53,8 @@ class InspectorHelpers {
                                                   JsValueRef expression,
                                                   bool returnByValue,
                                                   bool* isError = nullptr);
+  static v8::Local<v8::Value> EvaluateOnGlobalCallFrame(
+      JsValueRef expression, bool returnByValue, bool* isError = nullptr);
 
   static v8::Local<v8::Value> GetScriptSource(unsigned int scriptId);
 

--- a/deps/chakrashim/src/v8map.cc
+++ b/deps/chakrashim/src/v8map.cc
@@ -28,6 +28,7 @@ Local<Map> Map::New(Isolate* isolate) {
 
   JsValueRef newMapRef;
   if (jsrt::ConstructObject(mapConstructor, &newMapRef) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Local<Map>();
   }
 
@@ -39,8 +40,10 @@ MaybeLocal<Value> Map::Get(Local<Context> context, Local<Value> key) {
     ContextShim::GetCurrent()->GetMapGetFunction();
 
   JsValueRef mapGetResult;
-  if (jsrt::CallFunction(mapGetFunction, (JsValueRef)this, *key,
-                         &mapGetResult) != JsNoError) {
+  JsValueRef args[] = { (JsValueRef)this, *key };
+  if (JsCallFunction(mapGetFunction, args, _countof(args),
+                     &mapGetResult) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return MaybeLocal<Value>();
   }
 
@@ -53,8 +56,10 @@ MaybeLocal<Map> Map::Set(Local<Context> context, Local<Value> key,
     ContextShim::GetCurrent()->GetMapSetFunction();
 
   JsValueRef mapSetResult;
-  if (jsrt::CallFunction(mapSetFunction, (JsValueRef)this, *key, *value,
-                         &mapSetResult) != JsNoError) {
+  JsValueRef args[] = { (JsValueRef)this, *key, *value };
+  if (JsCallFunction(mapSetFunction, args, _countof(args),
+                     &mapSetResult) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return MaybeLocal<Map>();
   }
 
@@ -66,8 +71,10 @@ Maybe<bool> Map::Has(Local<Context> context, Local<Value> key) {
     ContextShim::GetCurrent()->GetMapHasFunction();
 
   JsValueRef mapHasResult;
-  if (jsrt::CallFunction(mapHasFunction, (JsValueRef)this, *key,
-                         &mapHasResult) != JsNoError) {
+  JsValueRef args[] = { (JsValueRef)this, *key };
+  if (JsCallFunction(mapHasFunction, args, _countof(args),
+                     &mapHasResult) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Nothing<bool>();
   }
 
@@ -76,6 +83,7 @@ Maybe<bool> Map::Has(Local<Context> context, Local<Value> key) {
                                           JsBooleanToBool,
                                           mapHasResult,
                                           &hasResult) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Nothing<bool>();
   }
 

--- a/deps/chakrashim/src/v8set.cc
+++ b/deps/chakrashim/src/v8set.cc
@@ -23,17 +23,31 @@
 namespace v8 {
 
 Local<Set> Set::New(Isolate* isolate) {
-  // CHAKRA-TODO: Figure out what to do here
-  //
-  // kpathak: chakra_shim.js
-  CHAKRA_ASSERT(false);
-  return Local<Set>();
+  JsValueRef setConstructor =
+    ContextShim::GetCurrent()->GetSetConstructor();
+
+  JsValueRef newSetRef;
+  if (jsrt::ConstructObject(setConstructor, &newSetRef) != JsNoError) {
+    CHAKRA_ASSERT(false);
+    return Local<Set>();
+  }
+
+  return Local<Set>::New(newSetRef);
 }
 
-MaybeLocal<Set> Set::Add(Local<Context>, Local<Value>) {
-  // CHAKRA-TODO: Figure out what to do here
-  CHAKRA_ASSERT(false);
-  return MaybeLocal<Set>();
+MaybeLocal<Set> Set::Add(Local<Context>, Local<Value> key) {
+  JsValueRef setAddFunction =
+    ContextShim::GetCurrent()->GetSetAddFunction();
+
+  JsValueRef setAddResult;
+  JsValueRef args[] = { (JsValueRef)this, *key };
+  if (JsCallFunction(setAddFunction, args, _countof(args),
+                     &setAddResult) != JsNoError) {
+    CHAKRA_ASSERT(false);
+    return MaybeLocal<Set>();
+  }
+
+  return Local<Set>::New(setAddResult);
 }
 
 Maybe<bool> Set::Delete(Local<Context>, Local<Value>) {
@@ -43,9 +57,24 @@ Maybe<bool> Set::Delete(Local<Context>, Local<Value>) {
 }
 
 Local<Array> Set::AsArray() const {
-  // CHAKRA-TODO: Figure out what to do here
-  CHAKRA_ASSERT(false);
-  return Local<Array>();
+  JsValueRef arrayConstructor =
+      ContextShim::GetCurrent()->GetArrayConstructor();
+
+  JsValueRef arrayFromFunction;
+  if (jsrt::GetProperty(arrayConstructor, jsrt::CachedPropertyIdRef::from,
+                        &arrayFromFunction) != JsNoError) {
+    CHAKRA_ASSERT(false);
+    return Local<Array>();
+  }
+
+  JsValueRef arrayFromResult;
+  if (jsrt::CallFunction(arrayFromFunction, (JsValueRef)this,
+                         &arrayFromResult) != JsNoError) {
+    CHAKRA_ASSERT(false);
+    return Local<Array>();
+  }
+
+  return Local<Array>::New(arrayFromResult);
 }
 
 }  // namespace v8

--- a/deps/chakrashim/src/v8stringobject.cc
+++ b/deps/chakrashim/src/v8stringobject.cc
@@ -42,8 +42,10 @@ Local<String> StringObject::ValueOf() const {
     ContextShim::GetCurrent()->GetValueOfFunction();
 
   JsValueRef stringObjectValue;
-  if (jsrt::CallFunction(valueOfFunction, (JsValueRef)this,
-                         &stringObjectValue) != JsNoError) {
+  JsValueRef args[] = { (JsValueRef)this };
+  if (JsCallFunction(valueOfFunction, args, _countof(args),
+                     &stringObjectValue) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Local<String>();
   }
 

--- a/deps/chakrashim/src/v8symbol.cc
+++ b/deps/chakrashim/src/v8symbol.cc
@@ -56,6 +56,7 @@ Local<Value> Symbol::Name() const {
 
   if (jsrt::CallFunction(getSymbolKeyForFunction, (JsValueRef)this,
                          &symbolDescription) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Local<Value>();
   }
 

--- a/deps/chakrashim/src/v8symbolobject.cc
+++ b/deps/chakrashim/src/v8symbolobject.cc
@@ -33,6 +33,7 @@ Local<Value> SymbolObject::New(Isolate* isolate, Local<Symbol> value) {
   JsValueRef newSymbolObjectRef;
   if (jsrt::ConstructObject(objectConstructor, *value,
                             &newSymbolObjectRef) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Local<Value>();
   }
 
@@ -44,8 +45,10 @@ Local<Symbol> SymbolObject::ValueOf() const {
     ContextShim::GetCurrent()->GetValueOfFunction();
 
   JsValueRef symbolObjectValue;
-  if (jsrt::CallFunction(valueOfFunction, (JsValueRef)this,
-                         &symbolObjectValue) != JsNoError) {
+  JsValueRef args[] = { (JsValueRef)this };
+  if (JsCallFunction(valueOfFunction, args, _countof(args),
+                     &symbolObjectValue) != JsNoError) {
+    CHAKRA_ASSERT(false);
     return Local<Symbol>();
   }
 

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -272,10 +272,7 @@ async function testCommandLineAPI(session) {
   checkException(result);
   assert.deepStrictEqual(JSON.parse(result['result']['value']), {
     parentsEqual: true,
-    parentId: common.engineSpecificMessage({
-      v8: '<inspector console>',
-      chakracore: '.'
-    })
+    parentId: '<inspector console>'
   });
   // the `require` in the module shadows the command line API's `require`
   result = await session.send(


### PR DESCRIPTION
* Fixed the way that Runtime::evaluate handled and returned exceptions
* Fixed Runtime::evaluate to use the global stack frame
* Added support for console command line during evaluate calls

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim