### PR TITLE
build,win: restore vcbuild TAG functionality

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -181,7 +181,6 @@ if "%target_arch%"=="arm" (
 )
 if defined config_flags     set configure_flags=%configure_flags% %config_flags%
 if defined target_arch      set configure_flags=%configure_flags% --dest-cpu=%target_arch%
-if defined TAG              set configure_flags=%configure_flags% --tag=%TAG%
 if defined engine           set configure_flags=%configure_flags% --engine=%engine%
 
 if not exist "%~dp0deps\icu" goto no-depsicu
@@ -190,6 +189,8 @@ if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
 call :getnodeversion || exit /b 1
+
+if defined TAG set configure_flags=%configure_flags% --tag=%TAG%
 
 if "%target%"=="Clean" rmdir /Q /S "%~dp0%config%\node-v%FULLVERSION%-win-%target_arch%" > nul 2> nul
 


### PR DESCRIPTION
Cherry-picking upstream change https://github.com/nodejs/node/commit/b225970e6ca05cab568273b100c5967b4209f621

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, win