### PR TITLE
chakrashim: implement new.target support native callbacks

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -1756,8 +1756,7 @@ class FunctionCallbackInfo {
   V8_INLINE Local<Value> operator[](int i) const;
   Local<Function> Callee() const { return _callee; }
   Local<Object> This() const { return _thisPointer; }
-  // TODO(jahorto): Implement this once JSRT gains new.target support
-  Local<Value> NewTarget() const { return nullptr; }
+  Local<Value> NewTarget() const { return _newTargetPointer; }
   Local<Object> Holder() const { return _holder; }
   bool IsConstructCall() const { return _isConstructorCall; }
   Local<Value> Data() const { return _data; }
@@ -1771,6 +1770,7 @@ class FunctionCallbackInfo {
     Value** args,
     int length,
     Local<Object> _this,
+    Local<Object> _newTarget,
     Local<Object> holder,
     bool isConstructorCall,
     Local<Value> data,
@@ -1778,6 +1778,7 @@ class FunctionCallbackInfo {
        : _args(args),
          _length(length),
          _thisPointer(_this),
+         _newTargetPointer(_newTarget),
          _holder(holder),
          _isConstructorCall(isConstructorCall),
          _data(data),
@@ -1789,6 +1790,7 @@ class FunctionCallbackInfo {
   Value** _args;
   int _length;
   Local<Object> _thisPointer;
+  Local<Object> _newTargetPointer;
   Local<Object> _holder;
   bool _isConstructorCall;
   Local<Value> _data;
@@ -2439,7 +2441,7 @@ class V8_EXPORT ObjectTemplate : public Template {
   friend class FunctionTemplateData;
   friend class Utils;
 
-  Local<Object> NewInstance(Handle<Object> prototype);
+  Local<Object> NewInstance(Handle<Function> constructor);
   void SetConstructor(Handle<FunctionTemplate> constructor);
 };
 

--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -22,7 +22,6 @@ prefix addons
 # These tests are failing for Node-Chakracore and should eventually be fixed
 async-hooks-promise/test : SKIP
 hello-world-esm/test : SKIP
-new-target/test : SKIP
 callback-scope/test : SKIP
 callback-scope/test-resolve-async : SKIP
 


### PR DESCRIPTION

Using the release/1.9 new Jsrt API to support callbacks
which can receive new.target.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim