### PR TITLE
test: add a new.target test to addons-napi

### DIFF
--- a/test/addons-napi/test_new_target/binding.c
+++ b/test/addons-napi/test_new_target/binding.c
@@ -1,0 +1,72 @@
+#include <node_api.h>
+#include "../common.h"
+
+napi_value BaseClass(napi_env env, napi_callback_info info) {
+  napi_value newTargetArg;
+  NAPI_CALL(env, napi_get_new_target(env, info, &newTargetArg));
+  napi_value thisArg;
+  NAPI_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &thisArg, NULL));
+  napi_value undefined;
+  NAPI_CALL(env, napi_get_undefined(env, &undefined));
+
+  // this !== new.target since we are being invoked through super()
+  bool result;
+  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, thisArg, &result));
+  NAPI_ASSERT(env, !result, "this !== new.target");
+
+  // new.target !== undefined because we should be called as a new expression
+  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
+  NAPI_ASSERT(env, !result, "new.target !== undefined");
+
+  return thisArg;
+}
+
+napi_value Constructor(napi_env env, napi_callback_info info) {
+  bool result;
+  napi_value newTargetArg;
+  NAPI_CALL(env, napi_get_new_target(env, info, &newTargetArg));
+  size_t argc = 1;
+  napi_value argv;
+  napi_value thisArg;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &argv, &thisArg, NULL));
+  napi_value undefined;
+  NAPI_CALL(env, napi_get_undefined(env, &undefined));
+
+  // new.target !== undefined because we should be called as a new expression
+  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
+  NAPI_ASSERT(env, !result, "new.target !== undefined");
+  
+  // arguments[0] should be Constructor itself (test harness passed it)
+  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, argv, &result));
+  NAPI_ASSERT(env, result, "new.target === Constructor");
+
+  return thisArg;
+}
+
+napi_value OrdinaryFunction(napi_env env, napi_callback_info info) {
+  bool result;
+  napi_value newTargetArg;
+  NAPI_CALL(env, napi_get_new_target(env, info, &newTargetArg));
+  napi_value undefined;
+  NAPI_CALL(env, napi_get_undefined(env, &undefined));
+
+  // new.target === undefined because we are not called as a new expression
+  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
+  NAPI_ASSERT(env, result, "new.target === undefined");
+
+  napi_value _true;
+  NAPI_CALL(env, napi_get_boolean(env, true, &_true));
+  return _true;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  const napi_property_descriptor desc[] = {
+    DECLARE_NAPI_PROPERTY("BaseClass", BaseClass),
+    DECLARE_NAPI_PROPERTY("OrdinaryFunction", OrdinaryFunction),
+    DECLARE_NAPI_PROPERTY("Constructor", Constructor)
+  };
+  NAPI_CALL(env, napi_define_properties(env, exports, 3, desc));
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_new_target/binding.gyp
+++ b/test/addons-napi/test_new_target/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.c' ]
+    }
+  ]
+}

--- a/test/addons-napi/test_new_target/test.js
+++ b/test/addons-napi/test_new_target/test.js
@@ -16,5 +16,6 @@ class Class extends binding.BaseClass {
 
 assert.ok(new Class() instanceof binding.BaseClass);
 assert.ok(new Class().ok);
-assert.ok(new binding.Constructor(binding.Constructor) instanceof binding.Constructor);
 assert.ok(binding.OrdinaryFunction());
+assert.ok(
+  new binding.Constructor(binding.Constructor) instanceof binding.Constructor);

--- a/test/addons-napi/test_new_target/test.js
+++ b/test/addons-napi/test_new_target/test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const binding = require(`./build/${common.buildType}/binding`);
+
+class Class extends binding.BaseClass {
+  constructor() {
+    super();
+    this.method();
+  }
+  method() {
+    this.ok = true;
+  }
+}
+
+assert.ok(new Class() instanceof binding.BaseClass);
+assert.ok(new Class().ok);
+assert.ok(new binding.Constructor(binding.Constructor) instanceof binding.Constructor);
+assert.ok(binding.OrdinaryFunction());


### PR DESCRIPTION

N-API testing for `new.target` is lacking. Rectify this.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test