### PR TITLE
[v8.x-cherrypick] http2,perf_hooks: perf state using AliasedBuffer

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -331,7 +331,7 @@ inline Environment::Environment(IsolateData* isolate_data,
   AssignToContext(context);
 
   destroy_async_id_list_.reserve(512);
-  performance_state_ = Calloc<performance::performance_state>(1);
+  performance_state_.reset(new performance::performance_state(isolate()));
   performance_state_->milestones[
       performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT] =
           PERFORMANCE_NOW();
@@ -363,7 +363,6 @@ inline Environment::~Environment() {
   delete[] heap_statistics_buffer_;
   delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;
-  free(performance_state_);
 }
 
 inline v8::Isolate* Environment::isolate() const {
@@ -537,7 +536,7 @@ inline void Environment::set_fs_stats_field_array(
 }
 
 inline performance::performance_state* Environment::performance_state() {
-  return performance_state_;
+  return performance_state_.get();
 }
 
 inline std::map<std::string, uint64_t>* Environment::performance_marks() {

--- a/src/env.h
+++ b/src/env.h
@@ -49,7 +49,7 @@ struct nghttp2_rcbuf;
 namespace node {
 
 namespace performance {
-struct performance_state;
+class performance_state;
 }
 
 namespace loader {
@@ -714,7 +714,7 @@ class Environment {
   size_t makecallback_cntr_;
   std::vector<double> destroy_async_id_list_;
 
-  performance::performance_state* performance_state_ = nullptr;
+  std::unique_ptr<performance::performance_state> performance_state_;
   std::map<std::string, uint64_t> performance_marks_;
 
 #if HAVE_INSPECTOR

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -41,10 +41,10 @@ void PerformanceEntry::New(const FunctionCallbackInfo<Value>& args) {
 
 void PerformanceEntry::NotifyObservers(Environment* env,
                                        PerformanceEntry* entry) {
-  uint32_t* observers = env->performance_state()->observers;
+  AliasedBuffer<uint32_t, v8::Uint32Array>& observers =
+      env->performance_state()->observers;
   PerformanceEntryType type = ToPerformanceEntryTypeEnum(entry->type().c_str());
-  if (observers == nullptr ||
-      type == NODE_PERFORMANCE_ENTRY_TYPE_INVALID ||
+  if (type == NODE_PERFORMANCE_ENTRY_TYPE_INVALID ||
       !observers[type]) {
     return;
   }
@@ -88,7 +88,8 @@ void Measure(const FunctionCallbackInfo<Value>& args) {
   Utf8Value startMark(isolate, args[1]);
   Utf8Value endMark(isolate, args[2]);
 
-  double* milestones = env->performance_state()->milestones;
+  AliasedBuffer<double, v8::Float64Array>& milestones =
+      env->performance_state()->milestones;
 
   uint64_t startTimestamp = timeOrigin;
   uint64_t start = GetPerformanceMark(env, *startMark);
@@ -155,7 +156,8 @@ void GetPerformanceEntryDuration(const Local<String> prop,
 void MarkMilestone(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
-  double* milestones = env->performance_state()->milestones;
+  AliasedBuffer<double, v8::Float64Array>& milestones =
+      env->performance_state()->milestones;
   PerformanceMilestone milestone =
       static_cast<PerformanceMilestone>(
           args[0]->Int32Value(context).ToChecked());
@@ -182,7 +184,8 @@ void PerformanceGCCallback(uv_async_t* handle) {
   Local<Object> obj;
   PerformanceGCKind kind = static_cast<PerformanceGCKind>(data->data());
 
-  uint32_t* observers = env->performance_state()->observers;
+  AliasedBuffer<uint32_t, v8::Uint32Array>& observers =
+      env->performance_state()->observers;
   if (!observers[NODE_PERFORMANCE_ENTRY_TYPE_GC]) {
     goto cleanup;
   }
@@ -285,8 +288,8 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().Set(ret.ToLocalChecked());
   }
 
-
-  uint32_t* observers = env->performance_state()->observers;
+  AliasedBuffer<uint32_t, v8::Uint32Array>& observers =
+      env->performance_state()->observers;
   if (!observers[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION])
     return;
 
@@ -319,16 +322,12 @@ void Init(Local<Object> target,
   performance_state* state = env->performance_state();
   auto state_ab = ArrayBuffer::New(isolate, state, sizeof(*state));
 
-  #define SET_STATE_TYPEDARRAY(name, type, field)                         \
-    target->Set(context,                                                  \
-                FIXED_ONE_BYTE_STRING(isolate, (name)),                   \
-                type::New(state_ab,                                       \
-                          offsetof(performance_state, field),             \
-                          arraysize(state->field)))                       \
-                                    .FromJust()
-    SET_STATE_TYPEDARRAY("observerCounts", v8::Uint32Array, observers);
-    SET_STATE_TYPEDARRAY("milestones", v8::Float64Array, milestones);
-  #undef SET_STATE_TYPEDARRAY
+  target->Set(context,
+              FIXED_ONE_BYTE_STRING(isolate, "observerCounts"),
+              state->observers.GetJSArray()).FromJust();
+  target->Set(context,
+              FIXED_ONE_BYTE_STRING(isolate, "milestones"),
+              state->milestones.GetJSArray()).FromJust();
 
   Local<String> performanceEntryString =
       FIXED_ONE_BYTE_STRING(isolate, "PerformanceEntry");

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -60,10 +60,33 @@ enum PerformanceEntryType {
                          node::performance::NODE_PERFORMANCE_MILESTONE_##n);  \
   } while (0);
 
-struct performance_state {
-  // doubles first so that they are always sizeof(double)-aligned
-  double milestones[NODE_PERFORMANCE_MILESTONE_INVALID];
-  uint32_t observers[NODE_PERFORMANCE_ENTRY_TYPE_INVALID];
+class performance_state {
+ public:
+  explicit performance_state(v8::Isolate* isolate) :
+    root(
+      isolate,
+      sizeof(performance_state_internal)),
+    milestones(
+      isolate,
+      offsetof(performance_state_internal, milestones),
+      NODE_PERFORMANCE_MILESTONE_INVALID,
+      root),
+    observers(
+      isolate,
+      offsetof(performance_state_internal, observers),
+      NODE_PERFORMANCE_ENTRY_TYPE_INVALID,
+      root) {}
+
+  AliasedBuffer<uint8_t, v8::Uint8Array> root;
+  AliasedBuffer<double, v8::Float64Array> milestones;
+  AliasedBuffer<uint32_t, v8::Uint32Array> observers;
+
+ private:
+  struct performance_state_internal {
+    // doubles first so that they are always sizeof(double)-aligned
+    double milestones[NODE_PERFORMANCE_MILESTONE_INVALID];
+    uint32_t observers[NODE_PERFORMANCE_ENTRY_TYPE_INVALID];
+  };
 };
 
 }  // namespace performance


### PR DESCRIPTION
Applying the patch from https://github.com/nodejs/node/pull/18364 to our local v8.x branch.  This resolves some TTD issues around modifying raw buffers that are exposed to script.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
perf_hooks