### PR TITLE
chakrashim: Fix `SetAccessorProperty` behavior

### DIFF
--- a/deps/chakrashim/src/v8template.cc
+++ b/deps/chakrashim/src/v8template.cc
@@ -57,8 +57,8 @@ void Template::SetAccessorProperty(
   if (properties != nullptr) {
     properties->SetAccessorProperty(
         name,
-        getter->GetFunction(),
-        setter->GetFunction(),
+        !getter.IsEmpty() ? getter->GetFunction() : Local<Function>(),
+        !setter.IsEmpty() ? setter->GetFunction() : Local<Function>(),
         attribute,
         access_control);
   }

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -396,8 +396,8 @@
       if (exceptionHandlerState.captureFn !== null) {
         exceptionHandlerState.captureFn(er);
       } else if (!process.emit('uncaughtException', er)) {
-      //ENABLE_TTD
-      NativeModule.require('trace_mgr').onUncaughtExceptionHandler();
+        //ENABLE_TTD
+        NativeModule.require('trace_mgr').onUncaughtExceptionHandler();
 
         // If someone handled it, then great.  otherwise, die in C++ land
         // since that means that we'll exit the process, emit the 'exit' event

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -238,7 +238,7 @@ function setupSignalHandlers() {
         process.emit('SIGINT');
       };
 
-      const signum = constants['SIGINT'];
+      const signum = constants.SIGINT;
       const err = wrap.start(signum);
       if (err) {
         wrap.close();

--- a/lib/trace_mgr.js
+++ b/lib/trace_mgr.js
@@ -263,11 +263,11 @@ function updateGlobalSampleStats(eventKind) {
   currentSampleRate[eventKind] *= emitOptions.backoffFactors[eventKind];
 
   var updateTime = new Date();
-  emitMinTimeValue['emitOnLogWarn'] = new Date(updateTime);
-  emitMinTimeValue['emitOnLogError'] = new Date(updateTime);
+  emitMinTimeValue.emitOnLogWarn = new Date(updateTime);
+  emitMinTimeValue.emitOnLogError = new Date(updateTime);
 
   if (eventKind === 'emitOnAssert') {
-    emitMinTimeValue['emitOnAssert'] = updateTime;
+    emitMinTimeValue.emitOnAssert = updateTime;
   }
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -46,7 +46,6 @@ namespace node {
 void FillStatsArray(v8::Local<v8::Float64Array> fields_array,
                     const uv_stat_t* s,
                     int offset) {
-
   Local<v8::ArrayBuffer> ab = fields_array->Buffer();
   double* fields = static_cast<double*>(ab->GetContents().Data()) + offset;
 

--- a/test/parallel/test-uv-binding-constant.js
+++ b/test/parallel/test-uv-binding-constant.js
@@ -12,10 +12,10 @@ keys.forEach((key) => {
   if (key.startsWith('UV_')) {
     const val = uv[key];
     assert.throws(() => uv[key] = 1,
-        common.engineSpecificMessage({
-            v8: /^TypeError: Cannot assign to read only property/,
-            chakracore: /^TypeError: Assignment to read-only properties is not allowed in strict mode$/
-        })
+                  common.engineSpecificMessage({
+                    v8: /^TypeError: Cannot assign to read only property/,
+                    chakracore: /^TypeError: Assignment to read-only properties is not allowed in strict mode$/
+                  })
     );
     assert.strictEqual(uv[key], val);
   }


### PR DESCRIPTION
`FunctionTemplate` asserts that it can get the external data from the
provided object. The assert was hitting because the caller was passing
in an empty `Local<FunctionTemplate>` object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim