### PR TITLE
ttd: fixing ttd hooks in node_file

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -211,17 +211,18 @@ void AfterInteger(uv_fs_t* req) {
   FSReqWrap* req_wrap = static_cast<FSReqWrap*>(req->data);
   FSReqAfterScope after(req_wrap, req);
 
-  if (after.Proceed()) {
 #if ENABLE_TTD_NODE
-        if (s_doTTRecord || s_doTTReplay) {
+  if (req->fs_type == UV_FS_READ && (s_doTTRecord || s_doTTReplay)) {
 #ifdef WIN32
-          byte* bufbase = reinterpret_cast<byte*>(req->fs.info.bufsml[0].base);
+    byte* bufbase = reinterpret_cast<byte*>(req->fs.info.bufsml[0].base);
 #else
-          byte* bufbase = reinterpret_cast<byte*>(req->bufsml[0].base);
+    byte* bufbase = reinterpret_cast<byte*>(req->bufsml[0].base);
 #endif
-          Buffer::TTDAsyncModNotify(bufbase + req->result);
-        }
+    Buffer::TTDAsyncModNotify(bufbase + req->result);
+  }
 #endif
+
+  if (after.Proceed()) {
     req_wrap->Resolve(Integer::New(req_wrap->env()->isolate(), req->result));
   }
 }


### PR DESCRIPTION
Some refactoring had caused TTD to fail whenever node::fs::AfterInteger
was called for a reason other than node::fs::Read.

Also moving the TTD component outside of the `after.Proceed` check to make sure that we always report the end of the period where libuv would be writing to the buffer.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
ttd