### PR TITLE
chakrashim: missing return for stubbed method

### DIFF
--- a/deps/chakrashim/src/v8v8.cc
+++ b/deps/chakrashim/src/v8v8.cc
@@ -254,6 +254,7 @@ namespace tracing {
 
   int64_t TracingController::CurrentTimestampMicroseconds() {
     jsrt::Unimplemented("TracingController");
+    return 0;
   }
 
   void TraceConfig::AddIncludedCategory(char const*) {


### PR DESCRIPTION
`TracingController::CurrentTimestampMicroseconds` is declared to return
an `int64_t`, but currently returns nothing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim