### PR TITLE
chakrashim: Fix Promise::Resolver

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -703,6 +703,7 @@ class Persistent : public PersistentBase<T> {
   friend class Utils;
   template <class F> friend class Local;
   template <class F> friend class ReturnValue;
+  friend class PromiseResolverData;
 
   V8_INLINE Persistent(T* that)
     : PersistentBase<T>(PersistentBase<T>::New(nullptr, that)) { }

--- a/deps/chakrashim/src/jsrtutils.cc
+++ b/deps/chakrashim/src/jsrtutils.cc
@@ -391,6 +391,12 @@ JsErrorCode GetPropertyNames(JsValueRef object,
     object, result);
 }
 
+JsPropertyIdRef GetExternalPropertyId() {
+  IsolateShim* iso = IsolateShim::GetCurrent();
+  return iso->GetCachedSymbolPropertyIdRef(
+      CachedSymbolPropertyIdRef::__external__);
+}
+
 JsErrorCode AddExternalData(JsValueRef ref,
                             JsPropertyIdRef externalDataPropertyId,
                             void *data,
@@ -413,11 +419,7 @@ JsErrorCode AddExternalData(JsValueRef ref,
 JsErrorCode AddExternalData(JsValueRef ref,
                             void *data,
                             JsFinalizeCallback onObjectFinalize) {
-  IsolateShim* iso = IsolateShim::GetCurrent();
-  JsPropertyIdRef propId = iso->GetCachedSymbolPropertyIdRef(
-    CachedSymbolPropertyIdRef::__external__);
-
-  return AddExternalData(ref, propId, data, onObjectFinalize);
+  return AddExternalData(ref, GetExternalPropertyId(), data, onObjectFinalize);
 }
 
 JsErrorCode GetExternalData(JsValueRef ref,
@@ -437,11 +439,7 @@ JsErrorCode GetExternalData(JsValueRef ref,
 
 JsErrorCode GetExternalData(JsValueRef ref,
                             void **data) {
-  IsolateShim* iso = IsolateShim::GetCurrent();
-  JsPropertyIdRef propId = iso->GetCachedSymbolPropertyIdRef(
-    CachedSymbolPropertyIdRef::__external__);
-
-  return GetExternalData(ref, propId, data);
+  return GetExternalData(ref, GetExternalPropertyId(), data);
 }
 
 JsErrorCode CreateFunctionWithExternalData(

--- a/deps/chakrashim/src/jsrtutils.h
+++ b/deps/chakrashim/src/jsrtutils.h
@@ -281,6 +281,8 @@ JsErrorCode CloneObject(JsValueRef source,
 JsErrorCode GetPropertyNames(JsValueRef object,
                              JsValueRef *namesArray);
 
+JsPropertyIdRef GetExternalPropertyId();
+
 JsErrorCode AddExternalData(JsValueRef ref,
                             JsPropertyIdRef externalDataPropertyId,
                             void *data,

--- a/deps/chakrashim/src/v8chakra.h
+++ b/deps/chakrashim/src/v8chakra.h
@@ -36,6 +36,7 @@ enum class ExternalDataTypes {
   ObjectData,
   FunctionTemplateData,
   FunctionCallbackData,
+  PromiseResolverData,
 };
 
 // Base class for external object data
@@ -74,6 +75,17 @@ class ExternalData {
   template <class T>
   static bool TryGet(JsValueRef ref, T** data) {
     return GetExternalData(ref, data) == JsNoError && *data != nullptr;
+  }
+
+  template <class T>
+  static bool TryGetFromProperty(JsValueRef ref, JsPropertyIdRef propertyId,
+                                 T** data) {
+    JsValueRef propertyValue = nullptr;
+    if (JsGetProperty(ref, propertyId, &propertyValue) != JsNoError) {
+      return false;
+    }
+
+    return T::TryGet(propertyValue, data);
   }
 };
 


### PR DESCRIPTION
The promisify function calls into native code to create a new
Promise::Resolver object and returns it back to script. In script it's
expected to be a promise object, but in our case it wasn't.

The solution is to hide the resolver data in an external object and
attach it to the promise object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim