### PR TITLE
test: mark a flaky test

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -40,6 +40,10 @@ test-inspector-contexts : SKIP
 test-inspector-scriptparsed-context : SKIP
 test-inspector-stop-profile-after-done : SKIP
 
+[$jsEngine==chakracore && $system==win32]
+# This test can fail depending on the ports that other processes are using
+test-inspector-port-cluster : PASS, FLAKY
+
 [$jsEngine==chakracore && $system==linux]
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-child-process-pass-fd : SKIP


### PR DESCRIPTION
test-inspector-port-cluster has been sometimes failing due to other
processes running in our build machine and listening on ports 1025 and
1026. In order to successfully run in a variety of machine
states, this test must be marked as flaky.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- test