### PR TITLE
chakrashim: Fix Error.captureStackTrace

### DIFF
--- a/deps/chakrashim/lib/chakra_shim.js
+++ b/deps/chakrashim/lib/chakra_shim.js
@@ -162,8 +162,8 @@
       const fileDetails = stackDetails[2].split(fileDetailsSplitter);
 
       const fileName = fileDetails[0];
-      const lineNumber = fileDetails[1] ? fileDetails[1] : 0;
-      const columnNumber = fileDetails[3] ? fileDetails[3] : 0;
+      const lineNumber = fileDetails[1] ? parseInt(fileDetails[1]) : 0;
+      const columnNumber = fileDetails[3] ? parseInt(fileDetails[3]) : 0;
 
       errstack.push(new StackFrame(func, funcName, fileName, lineNumber,
                                    columnNumber));


### PR DESCRIPTION
Error.captureStackTrace did not convert the type of line and column
numbers to numbers while creating the v8 capture objects. This breaks
modules which assumes number types. Changed to call parseInt if line
and column numbers are defined

Note: this fixes the failing Winston test in CITGM

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
chakrashim