### PR TITLE
lib: removing contents of v8 module under chakracore

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -14,6 +14,10 @@
 
 'use strict';
 
+if (process.jsEngine === 'chakracore') {
+  return;
+}
+
 const { Buffer } = require('buffer');
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 const {

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -173,6 +173,11 @@ test-fs-readdir-stack-overflow : SKIP
 # in a particular way which is true for v8 but not true for charkacore
 test-string-decoder-end : SKIP
 
+# These tests use the v8 module which chakracore does not support
+test-process-exception-capture-should-abort-on-uncaught-setflagsfromstring : SKIP
+test-v8-flag-type-check : SKIP
+test-v8-stats : SKIP
+
 [$jsEngine==chakracore && $arch==x64]
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-buffer-includes : SKIP


### PR DESCRIPTION
The v8 module uses functionality which is not supported by chakracore.
Rather than expose stubs which have unexpected behavior, we now do not
expose anything in the v8 module, so dependant modules can do feature
detection.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
