### PR TITLE
test: prefer `common.isChakraEngine`

### DIFF
--- a/test/addons-napi/test_buffer/test.js
+++ b/test/addons-napi/test_buffer/test.js
@@ -9,7 +9,7 @@ assert.strictEqual(binding.newBuffer().toString(), binding.theText);
 assert.strictEqual(binding.newExternalBuffer().toString(), binding.theText);
 
 // Don't rely on Chakra's GC to behave the same as v8's.
-if (process.jsEngine !== 'chakracore') {
+if (!common.isChakraEngine) {
   console.log('gc1');
   global.gc();
   assert.strictEqual(binding.getDeleterCallCount(), 1);
@@ -23,7 +23,7 @@ assert.strictEqual(binding.bufferInfo(buffer), true);
 buffer = null;
 
 // Don't rely on Chakra's GC to behave the same as v8's.
-if (process.jsEngine !== 'chakracore') {
+if (!common.isChakraEngine) {
   global.gc();
   console.log('gc2');
   assert.strictEqual(binding.getDeleterCallCount(), 2);

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -265,7 +265,7 @@ class InspectorSession {
     if (!Array.isArray(values))
       values = [ values ];
 
-    if (process.jsEngine === 'chakracore') {
+    if (common.isChakraEngine) {
       // Only the first parameter is returned by ChakraCore
       values = values.slice(0, 1);
     }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -630,7 +630,7 @@ common.expectsError(
   // Test caching.
   const fs = process.binding('fs');
   const tmp = fs.close;
-  fs.close = common.mustCall(tmp, process.jsEngine === 'chakracore' ? 0 : 1);
+  fs.close = common.mustCall(tmp, common.isChakraEngine ? 0 : 1);
   function throwErr() {
     // eslint-disable-next-line prefer-assert-methods
     assert(

--- a/test/parallel/test-buffer-writedouble.js
+++ b/test/parallel/test-buffer-writedouble.js
@@ -2,7 +2,7 @@
 
 // Tests to verify doubles are correctly written
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const buffer = Buffer.allocUnsafe(16);
@@ -67,7 +67,7 @@ assert.strictEqual(buffer.readDoubleLE(8), -Infinity);
 buffer.writeDoubleBE(NaN, 0);
 buffer.writeDoubleLE(NaN, 8);
 
-if (process.jsEngine === 'chakracore') {
+if (common.isChakraEngine) {
   assert.ok(buffer.equals(new Uint8Array([
     0xFF, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0xFF

--- a/test/parallel/test-buffer-writefloat.js
+++ b/test/parallel/test-buffer-writefloat.js
@@ -2,7 +2,7 @@
 
 // Tests to verify floats are correctly written
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const buffer = Buffer.allocUnsafe(8);
@@ -51,7 +51,7 @@ assert.strictEqual(buffer.readFloatLE(4), -Infinity);
 buffer.writeFloatBE(NaN, 0);
 buffer.writeFloatLE(NaN, 4);
 assert.ok(buffer.equals(
-  process.jsEngine === 'chakracore' ?
+  common.isChakraEngine ?
     new Uint8Array([ 0xFF, 0xC0, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xFF ]) :
     new Uint8Array([ 0x7F, 0xC0, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x7F ])));
 

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -116,7 +116,7 @@ syntaxArgs.forEach(function(args) {
   const c = spawnSync(node, args, { encoding: 'utf8', input: stdin });
 
   // stderr should include '[stdin]' as the filename
-  if (process.jsEngine === 'v8') {
+  if (!common.isChakraEngine) {
     assert(c.stderr.startsWith('[stdin]'), `${c.stderr} starts with ${stdin}`);
   }
 

--- a/test/sequential/test-inspector-debug-brk-flag.js
+++ b/test/sequential/test-inspector-debug-brk-flag.js
@@ -17,7 +17,7 @@ async function testBreakpointOnStart(session) {
       'params': { 'maxDepth': 0 } }
   ];
 
-  if (process.jsEngine !== 'chakracore') {
+  if (!common.isChakraEngine) {
     commands.push(
       { 'method': 'Profiler.enable' },
       { 'method': 'Profiler.setSamplingInterval',

--- a/test/sequential/test-inspector-exception.js
+++ b/test/sequential/test-inspector-exception.js
@@ -22,7 +22,7 @@ async function testBreakpointOnStart(session) {
       'params': { 'maxDepth': 0 } }
   ];
 
-  if (process.jsEngine !== 'chakracore') {
+  if (!common.isChakraEngine) {
     commands.push(
       { 'method': 'Profiler.enable' },
       { 'method': 'Profiler.setSamplingInterval',

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -73,7 +73,7 @@ async function testBreakpointOnStart(session) {
       'params': { 'maxDepth': 0 } }
   ];
 
-  if (process.jsEngine !== 'chakracore') {
+  if (!common.isChakraEngine) {
     commands.push(
       { 'method': 'Profiler.enable' },
       { 'method': 'Profiler.setSamplingInterval',


### PR DESCRIPTION
Replace usages of `process.jsEngine` in tests with
`common.isChakraEngine` checks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
