### PR TITLE
lib,test: stop using `process.jsEngine`

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -217,7 +217,7 @@ function innerOk(fn, argLen, value, message) {
     if (argLen === 0) {
       generatedMessage = true;
       message = 'No value argument passed to `assert.ok()`';
-    } else if (message == null && process.jsEngine !== 'chakracore') {
+    } else if (message == null && !('chakracore' in process.versions)) {
       // Use the call as error message if possible.
       // This does not work with e.g. the repl.
       const err = new Error();
@@ -245,7 +245,7 @@ function innerOk(fn, argLen, value, message) {
       expected: true,
       message,
       operator: '==',
-      stackStartFn: process.jsEngine === 'chakracore' ? ok : fn
+      stackStartFn: 'chakracore' in process.versions ? ok : fn
     });
     err.generatedMessage = generatedMessage;
     throw err;

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -29,7 +29,7 @@
     // do this good and early, since it handles errors.
     setupProcessFatal();
 
-    if (process.jsEngine === 'chakracore') {
+    if ('chakracore' in process.versions) {
       // This file contains the V8-specific "%<function>" syntax for accessing
       // private functions. This is not supported on ChakraCore and causes a
       // parser failure. Inject a cache entry to prevent the file from being

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1482,13 +1482,13 @@ function isRecoverableError(e, code) {
       return true;
     }
 
-    if (process.jsEngine === 'v8') {
+    if ('v8' in process.versions) {
       if (message === 'missing ) after argument list') {
         const frames = e.stack.split(/\r?\n/);
         const pos = frames.findIndex((f) => f.match(/^\s*\^+$/));
         return pos > 0 && frames[pos - 1].length === frames[pos].length;
       }
-    } else if (process.jsEngine.match(/^chakra/)) {
+    } else if ('chakracore' in process.versions) {
       if (/^(Expected|Unterminated)/.test(message) &&
             !/ in regular expression$/.test(message)) {
         return true;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -47,7 +47,7 @@ Object.defineProperty(exports, 'PORT', {
 
 
 exports.isWindows = process.platform === 'win32';
-exports.isChakraEngine = process.jsEngine === 'chakracore';
+exports.isChakraEngine = 'chakracore' in process.versions;
 exports.isWOW64 = exports.isWindows &&
                   (process.env.PROCESSOR_ARCHITEW6432 !== undefined);
 exports.isAIX = process.platform === 'aix';
@@ -618,8 +618,14 @@ exports.engineSpecificMessage = function(messageObject) {
   assert.ok(!areAllValuesStringEqual(messageObject),
             'Unnecessary usage of \'engineSpecificMessage\'');
 
-  const jsEngine = process.jsEngine || 'v8'; //default is 'v8'
-  return messageObject[jsEngine];
+  for (const version of Object.getOwnPropertyNames(process.versions)) {
+    const message = messageObject[version];
+    if (message !== undefined) {
+      return message;
+    }
+  }
+
+  return undefined;
 };
 
 exports.busyLoop = function busyLoop(time) {


### PR DESCRIPTION
Replace calls to process.jsEngine with property checks of the
`process.versions` object.

This doesn't address all of them, but makes a bit of progress.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
