### PR TITLE
chakrashim: add warning for ignored engine flags

### DIFF
--- a/deps/chakrashim/src/v8v8.cc
+++ b/deps/chakrashim/src/v8v8.cc
@@ -118,9 +118,6 @@ static bool startsWith(const char* str, const char (&prefix)[N]) {
   return strncmp(str, prefix, N - 1) == 0;
 }
 
-
-
-
 void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
   for (int i = 1; i < *argc; i++) {
     // Note: Node now exits on invalid options. We may not recognize V8 flags
@@ -142,18 +139,24 @@ void V8::SetFlagsFromCommandLine(int *argc, char **argv, bool remove_flags) {
         argv[i] = nullptr;
       }
     } else if (equals("--trace-debug-json", arg) ||
-      equals("--trace_debug_json", arg)) {
+               equals("--trace_debug_json", arg)) {
       g_trace_debug_json = true;
       if (remove_flags) {
         argv[i] = nullptr;
       }
-    } else if (remove_flags &&
-               (startsWith(
-                 arg, "--debug")  // Ignore some flags to reduce unit test noise
-                || startsWith(arg, "--harmony")
-                || startsWith(arg, "--stack-size=")
-                || startsWith(arg, "--nolazy"))) {
-      argv[i] = nullptr;
+    } else if (startsWith(arg, "--debug") ||
+               startsWith(arg, "--harmony") ||
+               startsWith(arg, "--max-old-space-size=") ||
+               startsWith(arg, "--nolazy") ||
+               startsWith(arg, "--stack-size=")) {
+      // Ignore some flags to reduce compatibility issues. These flags don't
+      // have any functionality differences in ChakraCore and are generally
+      // invisible to the running code.
+      fprintf(stderr, "Warning: Ignored engine flag: %s\n", arg);
+
+      if (remove_flags) {
+        argv[i] = nullptr;
+      }
     } else if (equals("--help", arg)) {
         printf(
           "Options:\n"

--- a/lib/trace_mgr.js
+++ b/lib/trace_mgr.js
@@ -476,7 +476,8 @@ const directIsAbsolute = (process.platform === 'win32') ?
 * Create and return a fuzzy stack match for the current call.
 */
 function generateFuzzyStack(eventKind) {
-  //Create an array of the file/lines for user space code in the call stack
+  // Create an array of the file/lines for user space code in the call stack.
+  // eslint-disable-next-line no-restricted-syntax
   let errstk = new Error()
     .stack
     .split('\n')


### PR DESCRIPTION
* Added a warning for any ignored engine-specific flags.
* Added `--max-old-space-size=` to the list of ignored flags.

Fixes #486

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
