### PR TITLE
src: fix warnings in aliased_buffer

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -127,13 +127,11 @@ class AliasedBuffer {
           index_(that.index_) {
     }
 
-    template <typename T>
-    inline Reference& operator=(const T& val) {
+    inline Reference& operator=(const NativeT& val) {
       aliased_buffer_->SetValue(index_, val);
       return *this;
     }
 
-    // This is not caught by the template operator= above.
     inline Reference& operator=(const Reference& val) {
       return *this = static_cast<NativeT>(val);
     }
@@ -142,9 +140,8 @@ class AliasedBuffer {
       return aliased_buffer_->GetValue(index_);
     }
 
-    template <typename T>
-    inline Reference& operator+=(const T& val) {
-      const T current = aliased_buffer_->GetValue(index_);
+    inline Reference& operator+=(const NativeT& val) {
+      const NativeT current = aliased_buffer_->GetValue(index_);
       aliased_buffer_->SetValue(index_, current + val);
       return *this;
     }
@@ -153,9 +150,10 @@ class AliasedBuffer {
       return this->operator+=(static_cast<NativeT>(val));
     }
 
-    template <typename T>
-    inline Reference& operator-=(const T& val) {
-      return this->operator+=(-val);
+    inline Reference& operator-=(const NativeT& val) {
+      const NativeT current = aliased_buffer_->GetValue(index_);
+      aliased_buffer_->SetValue(index_, current - val);
+      return *this;
     }
 
    private:


### PR DESCRIPTION
* Unary minus usages on unsigned type
* Implicit casts to/from input parameters

Just looking for feedback from this group first, then I'll open a PR upstream.  I saw these warnings while working on another issue and I believe these fixes to be equivalent to the implicit conversions that were happening before.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
