### PR TITLE
test: re-enable assert_throws_stack tests for node-chakracore

### DIFF
--- a/test/message/assert_throws_stack.chakracore.out
+++ b/test/message/assert_throws_stack.chakracore.out
@@ -1,9 +1,15 @@
-assert.js:*
-      compareExceptionKey(actual, expected, key, msg);
+assert.js:428
+      compareExceptionKey(actual, expected, key, msg, keys);
       ^
 
-AssertionError [ERR_ASSERTION]: bar: expected true, not undefined
-   at Anonymous function (*assert_throws_stack.js:*:*)
+AssertionError [ERR_ASSERTION]: Input A expected to deepStrictEqual input B:
++ expected - actual
+
+- Comparison {}
++ Comparison {
++   bar: true
++ }
+   at Anonymous function (*assert_throws_stack.js:*)
    at *
    at *
    at *

--- a/test/message/assert_throws_stack.chakracore.out
+++ b/test/message/assert_throws_stack.chakracore.out
@@ -1,4 +1,4 @@
-assert.js:428
+assert.js:*
       compareExceptionKey(actual, expected, key, msg, keys);
       ^
 

--- a/test/message/assert_throws_stack.js
+++ b/test/message/assert_throws_stack.js
@@ -3,8 +3,4 @@
 require('../common');
 const assert = require('assert').strict;
 
-// Temporarily disabled on chakra.
-const common = require('../common');
-if (!common.isChakraEngine) {
 assert.throws(() => { throw new Error('foo'); }, { bar: true });
-}


### PR DESCRIPTION

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
