### PR TITLE
chakrashim: remove `constexpr` usage

### DIFF
--- a/deps/chakrashim/include/v8.h
+++ b/deps/chakrashim/include/v8.h
@@ -2073,8 +2073,6 @@ class V8_EXPORT ArrayBufferView : public Object {
 
 class V8_EXPORT TypedArray : public ArrayBufferView {
  public:
-  static constexpr size_t kMaxLength =
-      sizeof(void*) == 4 ? (1u << 30) - 1 : (1u << 31) - 1;
   size_t Length();
   static TypedArray* Cast(Value* obj);
  private:


### PR DESCRIPTION
Node v8.x still supports VS2013 for building extensions. Because of this
`constexpr` is not supported. This field isn't required by any code in
v8.x anyway, so just remove it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
