### PR TITLE
deps: fix libuv registry API error handling

### DIFF
--- a/deps/uv/src/win/util.c
+++ b/deps/uv/src/win/util.c
@@ -615,7 +615,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
   SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION* sppi;
   DWORD sppi_size;
   SYSTEM_INFO system_info;
-  DWORD cpu_count, r, i;
+  DWORD cpu_count, i;
   NTSTATUS status;
   ULONG result_size;
   int err;
@@ -670,34 +670,33 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
 
     assert(len > 0 && len < ARRAY_SIZE(key_name));
 
-    r = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-                      key_name,
-                      0,
-                      KEY_QUERY_VALUE,
-                      &processor_key);
-    if (r != ERROR_SUCCESS) {
-      err = GetLastError();
+    err = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                        key_name,
+                        0,
+                        KEY_QUERY_VALUE,
+                        &processor_key);
+    if (err != ERROR_SUCCESS) {
       goto error;
     }
 
-    if (RegQueryValueExW(processor_key,
-                         L"~MHz",
-                         NULL,
-                         NULL,
-                         (BYTE*) &cpu_speed,
-                         &cpu_speed_size) != ERROR_SUCCESS) {
-      err = GetLastError();
+    err = RegQueryValueExW(processor_key,
+                           L"~MHz",
+                           NULL,
+                           NULL,
+                           (BYTE*)&cpu_speed,
+                           &cpu_speed_size);
+    if (err != ERROR_SUCCESS) {
       RegCloseKey(processor_key);
       goto error;
     }
 
-    if (RegQueryValueExW(processor_key,
-                         L"ProcessorNameString",
-                         NULL,
-                         NULL,
-                         (BYTE*) &cpu_brand,
-                         &cpu_brand_size) != ERROR_SUCCESS) {
-      err = GetLastError();
+    err = RegQueryValueExW(processor_key,
+                           L"ProcessorNameString",
+                           NULL,
+                           NULL,
+                           (BYTE*)&cpu_brand,
+                           &cpu_brand_size);
+    if (err != ERROR_SUCCESS) {
       RegCloseKey(processor_key);
       goto error;
     }

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -208,3 +208,25 @@ test-repl-sigint-nested-eval : SKIP
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-repl-sigint-nested-eval : SKIP
 test-vm-sigint : SKIP
+
+[$jsEngine==chakracore && $system==win32 && $arch==arm]
+# These tests depend on Git/Linux tools that don't exist on WoA
+test-child-process-double-pipe : SKIP
+test-child-process-set-blocking : SKIP
+test-child-process-spawn-shell : SKIP
+test-child-process-spawn-typeerror : SKIP
+test-child-process-spawnsync-input : SKIP
+test-child-process-spawnsync-shell : SKIP
+test-child-process-stdin : SKIP
+test-child-process-stdio-inherit : SKIP
+test-handle-wrap-isrefed : SKIP
+test-http-chunk-problem : SKIP
+test-pipe-head : SKIP
+test-process-kill-null : SKIP
+test-stdio-closed : SKIP
+
+# These tests try to spawn a detached window, there's not shell on Windows IoT
+test-cluster-fork-windowsHide : SKIP
+
+# ChakraCore doesn't support WASM on WoA
+test-wasm-simple : SKIP

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -44,3 +44,7 @@ test-inspector-port-cluster : PASS, FLAKY
 [$jsEngine==chakracore && $system==linux]
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-child-process-pass-fd : SKIP
+
+[$jsEngine==chakracore && $system==win32 && $arch==arm]
+# Inspector isn't currently supported on WoA
+test-inspector-port-zero-cluster : SKIP


### PR DESCRIPTION
The `Reg*` APIs on Windows don't use `GetLastError` to report failures.
The errors are returned directly from the call.

For systems which don't have one of the values `GetLastError` can end
up returning `0` to the caller, indicating success. The caller then
assumes that the data is valid and can attempt to execute on garbage
data. This change fixes the flow to correctly return the error to the
caller.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
