### PR TITLE
lib: make sure `console` is writable

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -378,7 +378,8 @@
     Object.defineProperty(global, 'console', {
       configurable: true,
       enumerable: false,
-      value: wrappedConsole
+      value: wrappedConsole,
+      writable: true
     });
     setupInspector(originalConsole, wrappedConsole, CJSModule);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

The code currently assumes that `console` is already writable, but
that's only if it was previously defined as writable. If it hasn't
already been defined then the default value is false.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
