### PR TITLE
build: fix ChakraCore inspector build

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -717,53 +717,69 @@
       'toolsets': ['host'],
       'conditions': [
         [ 'v8_enable_inspector==1', {
-          'actions': [
-            {
-              'action_name': 'v8_inspector_copy_protocol_to_intermediate_folder',
-              'inputs': [ 'deps/v8/src/inspector/js_protocol.pdl' ],
-              'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/js_protocol.pdl' ],
-              'action': [ 'cp', '<@(_inputs)', '<(SHARED_INTERMEDIATE_DIR)' ],
-            },
-            {
-              'action_name': 'v8_inspector_convert_protocol_to_json',
-              'inputs': [
-                '<(SHARED_INTERMEDIATE_DIR)/js_protocol.pdl',
-              ],
-              'outputs': [
-                '<(SHARED_INTERMEDIATE_DIR)/js_protocol.json',
-              ],
-              'action': [
-                'python',
-                'deps/v8/third_party/inspector_protocol/ConvertProtocolToJSON.py',
-                '<@(_inputs)',
-                '<@(_outputs)',
-              ],
-            },
-            {
-              'action_name': 'v8_inspector_compress_protocol_json',
-              'process_outputs_as_sources': 1,
-              'outputs': [
-                '<(SHARED_INTERMEDIATE_DIR)/v8_inspector_protocol_json.h',
-              ],
-              'action': [
-                'python',
-                'tools/compress_json.py',
-                '<@(_inputs)',
-                '<@(_outputs)',
-              ],
-              'conditions': [
-                [ 'node_engine=="chakracore"', {
+          'conditions': [
+            [ 'node_engine=="v8"', {
+              'actions': [
+                {
+                  'action_name': 'v8_inspector_copy_protocol_to_intermediate_folder',
+                  'inputs': [ 'deps/v8/src/inspector/js_protocol.pdl' ],
+                  'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/js_protocol.pdl' ],
+                  'action': [ 'cp', '<@(_inputs)', '<(SHARED_INTERMEDIATE_DIR)' ],
+                },
+                {
+                  'action_name': 'v8_inspector_convert_protocol_to_json',
                   'inputs': [
-                    'deps/chakrashim/src/inspector/js_protocol.json',
+                    '<(SHARED_INTERMEDIATE_DIR)/js_protocol.pdl',
                   ],
-                }, {
+                  'outputs': [
+                    '<(SHARED_INTERMEDIATE_DIR)/js_protocol.json',
+                  ],
+                  'action': [
+                    'python',
+                    'deps/v8/third_party/inspector_protocol/ConvertProtocolToJSON.py',
+                    '<@(_inputs)',
+                    '<@(_outputs)',
+                  ],
+                },
+                {
+                  'action_name': 'v8_inspector_compress_protocol_json',
+                  'process_outputs_as_sources': 1,
                   'inputs': [
                     '<(SHARED_INTERMEDIATE_DIR)/js_protocol.json',
                   ],
-                }],
+                  'outputs': [
+                    '<(SHARED_INTERMEDIATE_DIR)/v8_inspector_protocol_json.h',
+                  ],
+                  'action': [
+                    'python',
+                    'tools/compress_json.py',
+                    '<@(_inputs)',
+                    '<@(_outputs)',
+                  ],
+                },
               ],
-            },
-          ],
+            }],
+            [ 'node_engine=="chakracore"', {
+              'actions': [
+                {
+                  'action_name': 'v8_inspector_compress_protocol_json',
+                  'process_outputs_as_sources': 1,
+                  'inputs': [
+                    'deps/chakrashim/src/inspector/js_protocol.json',
+                  ],
+                  'outputs': [
+                    '<(SHARED_INTERMEDIATE_DIR)/v8_inspector_protocol_json.h',
+                  ],
+                  'action': [
+                    'python',
+                    'tools/compress_json.py',
+                    '<@(_inputs)',
+                    '<@(_outputs)',
+                  ],
+                },
+              ],
+            }]
+          ]
         }],
       ],
     },


### PR DESCRIPTION
V8 changed the way they build their protocol, but since ChakraCore
still uses the JSON directly we don't require the same build steps.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
