### PR TITLE
build: fix chakracore dependency

### DIFF
--- a/deps/chakrashim/chakrashim.gyp
+++ b/deps/chakrashim/chakrashim.gyp
@@ -177,6 +177,7 @@
       'actions': [
         {
           'action_name': 'chakra_js2c',
+          'process_outputs_as_sources': 1,
           'inputs': [
             '<@(library_files)'
           ],

--- a/node.gypi
+++ b/node.gypi
@@ -137,6 +137,7 @@
         'deps/chakrashim', # include/v8_platform.h
       ],
       'dependencies': [
+        'deps/chakrashim/chakracore.gyp:chakracore#host',
         'deps/chakrashim/chakrashim.gyp:chakrashim'
       ],
       'conditions': [


### PR DESCRIPTION
When building with a single worker the chakracore build doesn't occur
until too late. Adding a direct dependency on chakracore seems to fix
the issue.

Fixes: https://github.com/nodejs/node-chakracore/issues/512

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
