### PR TITLE
deps: updating incorrect usage of HandleScope

### DIFF
--- a/deps/chakrashim/src/v8functiontemplate.cc
+++ b/deps/chakrashim/src/v8functiontemplate.cc
@@ -101,7 +101,7 @@ class FunctionCallbackData : public ExternalData {
     // CHAKRA_CALLBACK in the current callee context.
     ContextShim* contextShim = IsolateShim::GetContextShimOfObject(callee);
     ContextShim::Scope contextScope(contextShim);
-    HandleScope scope(nullptr);
+    HandleScope scope(Isolate::GetCurrent());
 
     FunctionCallbackData* callbackData = nullptr;
     if (!ExternalData::TryGet(JsValueRef(callbackState), &callbackData)) {


### PR DESCRIPTION
HandleScope should take an Isolate, but we currently fake it in the
shim. To avoid issues I added an assert that we were in the isolate
that we thought we were, but this one instance was ignoring that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
