### PR TITLE
deps: ensure that uv handles are cleaned up before freeing them

### DIFF
--- a/deps/chakrashim/src/jsrtisolateshim.cc
+++ b/deps/chakrashim/src/jsrtisolateshim.cc
@@ -243,8 +243,15 @@ IsolateShim::~IsolateShim() {
   assert(this->prevnext == nullptr);
 
   if (IsolateShim::IsIdleGcEnabled()) {
+    uv_prepare_stop(idleGc_prepare_handle());
     uv_close(reinterpret_cast<uv_handle_t*>(idleGc_prepare_handle()), nullptr);
+    uv_timer_stop(idleGc_timer_handle());
     uv_close(reinterpret_cast<uv_handle_t*>(idleGc_timer_handle()), nullptr);
+    // We need to run the UV loop to properly clean up these handles,
+    // but we don't want to run much script code since we are tearing
+    // down the isolate. UV_RUN_NOWAIT should clean up the handles
+    // with the least amount of additonal work.
+    uv_run(uv_default_loop(), UV_RUN_NOWAIT); 
   }
 }
 
@@ -297,8 +304,7 @@ IsolateShim::~IsolateShim() {
     uv_prepare_init(uv_default_loop(), newIsolateshim->idleGc_prepare_handle());
     uv_unref(reinterpret_cast<uv_handle_t*>(
       newIsolateshim->idleGc_prepare_handle()));
-    uv_timer_init(uv_default_loop(),
-      newIsolateshim->idleGc_timer_handle());
+    uv_timer_init(uv_default_loop(), newIsolateshim->idleGc_timer_handle());
     uv_unref(reinterpret_cast<uv_handle_t*>(
       newIsolateshim->idleGc_timer_handle()));
   }


### PR DESCRIPTION
Our IsolateShim has a few libuv handles in it which form part of
a list of handles. When the shim is freed, we close the handles,
but without running the UV loop they don't get properly cleaned up
and so we could run into use-after-free situations.

This is unlikely to have impacted normal node scenarios since we
do not support multiple isolates at the same time, but it impacts
cctest which creates several isolates in sequence.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
