### PR TITLE
build: remove ChakraCore tests from source tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -907,6 +907,7 @@ $(TARBALL): release-only $(NODE_EXE) doc
 	$(RM) -r $(TARNAME)/.editorconfig
 	$(RM) -r $(TARNAME)/.git*
 	$(RM) -r $(TARNAME)/.mailmap
+	$(RM) -r $(TARNAME)/deps/chakrashim/core/test
 	$(RM) -r $(TARNAME)/deps/openssl/openssl/demos
 	$(RM) -r $(TARNAME)/deps/openssl/openssl/doc
 	$(RM) -r $(TARNAME)/deps/openssl/openssl/test


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

It is now possible to publish a source tarball and documentation folder in Node-ChakraCore releases/nightlies. This removes the ChakraCore engine tests folder to save space, like what is already done for other dependencies. Saves 13M on the `gz` and 7M on the `xz` archives.

There might be other candidates for removal and I can add them here.

@kfarnung will this get pulled to the `v8.x` and `v10.x` branches or should I open backport PRs?

Test build: https://nodejs.org/download/test/v11.0.0-test20180528f6a2e99c80/

cc @digitalinfinity 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
