### PR TITLE
tools: replace object spread with assign

### DIFF
--- a/tools/build-addons.js
+++ b/tools/build-addons.js
@@ -34,7 +34,7 @@ async function runner(directoryQueue) {
     await execFile(process.execPath, [nodeGyp, 'rebuild', `--directory=${dir}`],
                    {
                      stdio: 'inherit',
-                     env: { ...process.env, MAKEFLAGS: '-j1' }
+                     env: Object.assign({}, process.env, { MAKEFLAGS: '-j1' })
                    });
 
   // We buffer the output and print it out once the process is done in order


### PR DESCRIPTION
ChakraCore doesn't currently support object spread, so use
`Object.assign` instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
