### PR TITLE
test: enable bigint tests on v8

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -227,7 +227,6 @@ class ZCtx : public AsyncWrap, public ThreadPoolWork {
           ttdbuf->TTDRawBufferModifyNotifySync(0, modSize);
         }
 #endif
-
       }
       ctx->Unref();
       return;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -496,7 +496,7 @@ function engineSpecificMessage(messageObject) {
   }
 
   return undefined;
-};
+}
 
 function busyLoop(time) {
   const startTime = Date.now();

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -107,7 +107,6 @@ test-trace-events-promises : SKIP
 test-trace-events-v8 : SKIP
 test-trace-events-vm : SKIP
 test-trace-events-worker-metadata : SKIP
-test-trace-event-promises : SKIP
 test-tracing-no-crash : SKIP
 
 # These tests are disabled for chakra engine because they depend
@@ -155,7 +154,6 @@ test-vm-module-link : SKIP
 test-vm-module-reevaluate : SKIP
 
 # This test requires support for bigints
-test-util-inspect-bigint : SKIP
 test-fs-stat-bigint : SKIP
 test-fs-watchfile-bigint : SKIP
 test-process-hrtime-bigint : SKIP

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -369,7 +369,8 @@ assertDeepAndStrictEqual(
   new Map([[null, 3]])
 );
 
-/* chakra doesn't support bigInt yet
+if (!common.isChakraEngine) {
+  eval(`
 assertOnlyDeepEqual(
   new Map([[undefined, null], ['+000', 2n]]),
   new Map([[null, undefined], [false, '2']]),
@@ -379,17 +380,8 @@ assertOnlyDeepEqual(
   new Set([null, '', 1n, 5, 2n, false]),
   new Set([undefined, 0, 5n, true, '2', '-000'])
 );
-*/
-
-assertOnlyDeepEqual(
-  new Map([[undefined, null], ['+000', 2]]),
-  new Map([[null, undefined], [false, '2']]),
-);
-
-assertOnlyDeepEqual(
-  new Set([null, '', 1, 5, 2, false]),
-  new Set([undefined, 0, 5, true, '2', '-000'])
-);
+  `);
+}
 
 assertNotDeepOrStrict(
   new Set(['']),


### PR DESCRIPTION
* Use eval to enable tests to run on v8 and chakracore
* Clean up status files
* Fix a lint issue

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
