### PR TITLE
test: mark `test-os-process-priority` flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -252,15 +252,17 @@ test-env-newprotomethod-remove-unnecessary-prototypes : SKIP
 test-buffer-sharedarraybuffer : SKIP
 test-assert-typedarray-deepequal : SKIP
 
-# Setting OS process priority is not yet supported
-test-os-process-priority : SKIP
-
 [$jsEngine==chakracore && $system==win32]
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-module-loading-globalpaths : SKIP
 
 # Depends on ICU behavior, enable when ICU is enabled on Windows
 test-intl: SKIP
+
+# This test seems to be broken upstrem on Windows (possibly due to the machine
+# configuration). Mark it flaky, but keep running it until a fix comes.
+# https://github.com/nodejs/node/issues/22799
+test-os-process-priority : PASS,FLAKY
 
 [$jsEngine==chakracore && $system==win32 && $arch==arm]
 # These tests depend on Git/Linux tools that don't exist on WoA


### PR DESCRIPTION
The test also fails in upstream node on my machine, mark it flaky on
Windows rather than skipping it.

Refs: https://github.com/nodejs/node/issues/22799

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
