### PR TITLE
n-api,test: stub out function

### DIFF
--- a/src/node_api_jsrt.cc
+++ b/src/node_api_jsrt.cc
@@ -3496,3 +3496,12 @@ napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func) {
   CHECK(func != nullptr);
   return reinterpret_cast<TsFn*>(func)->Ref();
 }
+
+napi_status napi_add_finalizer(napi_env env,
+                               napi_value js_object,
+                               void* native_object,
+                               napi_finalize finalize_cb,
+                               void* finalize_hint,
+                               napi_ref* result) {
+  return napi_ok;
+}

--- a/test/addons-napi/addons-napi.status
+++ b/test/addons-napi/addons-napi.status
@@ -20,5 +20,6 @@ prefix addons-napi
 
 [$jsEngine==chakracore]
 # These tests are failing for Node-Chakracore and should eventually be fixed
-test_env_sharing/test : SKIP
 test_bigint/test : SKIP
+test_env_sharing/test : SKIP
+test_general/testFinalizer : SKIP


### PR DESCRIPTION
There isn't a clean way to implement `napi_add_finalizer` in ChakraCore
so just fix the addon build and skip the test for now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
