### PR TITLE
test: skip GC behavior test on x86

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -253,6 +253,9 @@ test-env-newprotomethod-remove-unnecessary-prototypes : SKIP
 test-buffer-sharedarraybuffer : SKIP
 test-assert-typedarray-deepequal : SKIP
 
+# Depends on precise GC behavior
+test-zlib-invalid-input-memory : SKIP
+
 [$jsEngine==chakracore && $system==win32]
 # These tests are failing for Node-Chakracore and should eventually be fixed
 test-module-loading-globalpaths : SKIP


### PR DESCRIPTION
This test depends on precise GC behavior which isn't reliable using a
conservative GC on x86.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
