### PR TITLE
chakrashim: enable `resourceNameToUrl` support

### DIFF
--- a/deps/chakrashim/src/inspector/v8-debugger-script.cc
+++ b/deps/chakrashim/src/inspector/v8-debugger-script.cc
@@ -102,9 +102,8 @@ static JsErrorCode GetNamedStringValue(JsValueRef object,
   return JsNoError;
 }
 
-V8DebuggerScript::V8DebuggerScript(v8::Isolate* isolate,
-                                   JsValueRef scriptData,
-                                   bool isLiveEdit)
+V8DebuggerScript::V8DebuggerScript(v8::Isolate* isolate, JsValueRef scriptData,
+                                   bool isLiveEdit, V8InspectorClient* client)
   : m_startLine(0),
     m_startColumn(0),
     m_endColumn(0),
@@ -125,7 +124,9 @@ V8DebuggerScript::V8DebuggerScript(v8::Isolate* isolate,
   String16 urlValue;
   if (GetNamedStringValue(scriptData, jsrt::CachedPropertyIdRef::fileName,
                           &urlValue) == JsNoError) {
-    m_url = urlValue;
+    std::unique_ptr<StringBuffer> url =
+        client->resourceNameToUrl(toStringView(urlValue));
+    m_url = url ? toString16(url->string()) : urlValue;
   } else if (GetNamedStringValue(scriptData,
                                jsrt::CachedPropertyIdRef::scriptType,
                                &urlValue) == JsNoError) {

--- a/deps/chakrashim/src/inspector/v8-debugger-script.h
+++ b/deps/chakrashim/src/inspector/v8-debugger-script.h
@@ -37,11 +37,12 @@
 
 namespace v8_inspector {
 
+class V8InspectorClient;
+
 class V8DebuggerScript {
  public:
-  V8DebuggerScript(v8::Isolate* isolate,
-                   JsValueRef scriptData,
-                   bool isLiveEdit);
+  V8DebuggerScript(v8::Isolate* isolate, JsValueRef scriptData,
+                   bool isLiveEdit, V8InspectorClient* client);
   ~V8DebuggerScript();
 
   const String16& scriptId() const { return m_id; }

--- a/deps/chakrashim/src/inspector/v8-debugger.cc
+++ b/deps/chakrashim/src/inspector/v8-debugger.cc
@@ -90,7 +90,7 @@ void V8Debugger::getCompiledScripts(
     CHAKRA_VERIFY_NOERROR(jsrt::GetIndexedProperty(scripts, i, &script));
 
     result.push_back(wrapUnique(
-        new V8DebuggerScript(m_isolate, script, false)));
+        new V8DebuggerScript(m_isolate, script, false, m_inspector->client())));
   }
 }
 
@@ -445,7 +445,8 @@ void V8Debugger::HandleSourceEvents(JsValueRef eventData, bool success) {
 
   if (agent != nullptr) {
     agent->didParseSource(
-        wrapUnique(new V8DebuggerScript(m_isolate, eventData, false)),
+        wrapUnique(new V8DebuggerScript(m_isolate, eventData, false,
+                                        m_inspector->client())),
         success);
   }
 }

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -34,13 +34,6 @@ test-inspector-contexts : SKIP
 test-inspector-scriptparsed-context : SKIP
 test-inspector-stop-profile-after-done : SKIP
 
-# These need to be fixed when resourceNameToUrl is wired up.
-# https://github.com/nodejs/node-chakracore/issues/598
-test-inspector : SKIP
-test-inspector-debug-brk-flag : SKIP
-test-inspector-exception : SKIP
-test-inspector-resource-name-to-url : SKIP
-
 [$jsEngine==chakracore && $system==win32]
 # This test can fail depending on the ports that other processes are using
 test-inspector-port-cluster : PASS, FLAKY

--- a/test/sequential/test-inspector-resource-name-to-url.js
+++ b/test/sequential/test-inspector-resource-name-to-url.js
@@ -1,3 +1,4 @@
+// Flags: --inspect
 'use strict';
 const common = require('../common');
 


### PR DESCRIPTION
Wired up support for calling the node-provided `resourceNameToUrl`
method in the chakrashim inspector.

This reverts commit 3f6ef13890ac89779f36af5eb3ea276b617f8447.

Fixes: https://github.com/nodejs/node-chakracore/issues/598
Refs: https://github.com/nodejs/node/pull/22251
Refs: https://github.com/nodejs/node-chakracore/commit/3f6ef13890ac89779f36af5eb3ea276b617f8447

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
